### PR TITLE
enhancement: azure devops agent separate pat

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -163,6 +163,7 @@ jobs:
 
           if($versionControlSystem -eq "azuredevops") {
             $Inputs["azure_devops_personal_access_token"] = "${{ secrets.VCS_TOKEN_AZURE_DEVOPS }}"
+            $Inputs["azure_devops_agents_personal_access_token"] = "${{ secrets.VCS_TOKEN_AZURE_DEVOPS }}"
             $Inputs["azure_devops_organization_name"] = "${{ vars.VCS_ORGANIZATION }}"
             $Inputs["use_separate_repository_for_pipeline_templates"] = "true"
             $Inputs["azure_devops_use_organisation_legacy_url"] = "false"

--- a/alz/azuredevops/main.tf
+++ b/alz/azuredevops/main.tf
@@ -32,7 +32,7 @@ module "azure" {
   agent_container_instances                                 = local.agent_container_instances
   agent_container_instance_image                            = var.agent_container_image
   agent_organization_url                                    = module.azure_devops.organization_url
-  agent_token                                               = var.azure_devops_personal_access_token
+  agent_token                                               = var.azure_devops_agents_personal_access_token
   agent_organization_environment_variable                   = var.agent_organization_environment_variable
   agent_pool_environment_variable                           = var.agent_pool_environment_variable
   agent_name_environment_variable                           = var.agent_name_environment_variable

--- a/alz/azuredevops/variables.input.tf
+++ b/alz/azuredevops/variables.input.tf
@@ -77,20 +77,27 @@ variable "use_self_hosted_agents" {
   default     = true
 }
 
+variable "azure_devops_agents_personal_access_token" {
+  description = "Personal access token for Azure DevOps self-hosted agents (the token requires the 'Agent Pools - Read & Manage' scope and should have the maximum expiry). Only required if 'use_self_hosted_runners' is 'true'|15"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "use_private_networking" {
-  description = "Controls whether to use private networking for the agent to storage account communication|15"
+  description = "Controls whether to use private networking for the agent to storage account communication|16"
   type        = bool
   default     = true
 }
 
 variable "allow_storage_access_from_my_ip" {
-  description = "Allow access to the storage account from the current IP address. We recommend this is kept off for security|16"
+  description = "Allow access to the storage account from the current IP address. We recommend this is kept off for security|17"
   type        = bool
   default     = false
 }
 
 variable "apply_approvers" {
-  description = "Apply stage approvers to the action / pipeline, must be a list of SPNs separate by a comma (e.g. abcdef@microsoft.com,ghijklm@microsoft.com)|17"
+  description = "Apply stage approvers to the action / pipeline, must be a list of SPNs separate by a comma (e.g. abcdef@microsoft.com,ghijklm@microsoft.com)|18"
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Support separate PAT for Azure DevOps Agents. This allows for a longer expiry. This is a pre-requisite for ephemeral agents, but will help existing customers now.

## This PR fixes/adds/changes/removes

1. https://github.com/Azure/alz-terraform-accelerator/issues/88

### Breaking Changes

None

## Testing Evidence

e2e tests run

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
