### PR TITLE
fix: Bicep permissions for what-if

### DIFF
--- a/alz/azuredevops/variables.hidden.tf
+++ b/alz/azuredevops/variables.hidden.tf
@@ -229,7 +229,9 @@ variable "custom_role_definitions_bicep" {
           "Microsoft.Resources/deployments/write",
           "Microsoft.Resources/deployments/validate/action",
           "Microsoft.Resources/deployments/read",
-          "Microsoft.Resources/deployments/operationStatuses/read"
+          "Microsoft.Resources/deployments/operationStatuses/read",
+          "Microsoft.Authorization/roleAssignments/write",
+          "Microsoft.Authorization/roleAssignments/delete"
         ]
         not_actions = []
       }

--- a/alz/azuredevops/variables.hidden.tf
+++ b/alz/azuredevops/variables.hidden.tf
@@ -282,7 +282,8 @@ variable "custom_role_definitions_bicep" {
           "Microsoft.Authorization/locks/write",
           "Microsoft.Network/*/write",
           "Microsoft.Resources/deployments/whatIf/action",
-          "Microsoft.Resources/deployments/write"
+          "Microsoft.Resources/deployments/write",
+          "Microsoft.SecurityInsights/onboardingStates/write"
         ]
         not_actions = []
       }

--- a/alz/github/variables.hidden.tf
+++ b/alz/github/variables.hidden.tf
@@ -288,7 +288,8 @@ variable "custom_role_definitions_bicep" {
           "Microsoft.Authorization/locks/write",
           "Microsoft.Network/*/write",
           "Microsoft.Resources/deployments/whatIf/action",
-          "Microsoft.Resources/deployments/write"
+          "Microsoft.Resources/deployments/write",
+          "Microsoft.SecurityInsights/onboardingStates/write"
         ]
         not_actions = []
       }

--- a/alz/github/variables.hidden.tf
+++ b/alz/github/variables.hidden.tf
@@ -235,7 +235,9 @@ variable "custom_role_definitions_bicep" {
           "Microsoft.Resources/deployments/write",
           "Microsoft.Resources/deployments/validate/action",
           "Microsoft.Resources/deployments/read",
-          "Microsoft.Resources/deployments/operationStatuses/read"
+          "Microsoft.Resources/deployments/operationStatuses/read",
+          "Microsoft.Authorization/roleAssignments/write",
+          "Microsoft.Authorization/roleAssignments/delete"
         ]
         not_actions = []
       }

--- a/alz/local/variables.hidden.tf
+++ b/alz/local/variables.hidden.tf
@@ -170,8 +170,7 @@ variable "custom_role_definitions_bicep" {
           "Microsoft.Insights/diagnosticSettings/write",
           "Microsoft.Insights/diagnosticSettings/read",
           "Microsoft.Resources/deployments/whatIf/action",
-          "Microsoft.Resources/deployments/write",
-          "Microsoft.SecurityInsights/onboardingStates/write"
+          "Microsoft.Resources/deployments/write"
         ]
         not_actions = []
       }

--- a/alz/local/variables.hidden.tf
+++ b/alz/local/variables.hidden.tf
@@ -150,7 +150,9 @@ variable "custom_role_definitions_bicep" {
           "Microsoft.Resources/deployments/write",
           "Microsoft.Resources/deployments/validate/action",
           "Microsoft.Resources/deployments/read",
-          "Microsoft.Resources/deployments/operationStatuses/read"
+          "Microsoft.Resources/deployments/operationStatuses/read",
+          "Microsoft.Authorization/roleAssignments/write",
+          "Microsoft.Authorization/roleAssignments/delete"
         ]
         not_actions = []
       }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Fixes https://github.com/Azure/ALZ-PowerShell-Module/issues/183
Fixes https://github.com/Azure/ALZ-PowerShell-Module/issues/185

## This PR fixes/adds/changes/removes

1. Adds write permissions to onboardingStates
2. Adds write and delete authorization permissions for subscription plaecment module
3. Remove unneeded onboardingStates write permission and management group scope for local

### Breaking Changes

1. None

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
