### PR TITLE
feat: Using starter module tfvars for architecture definition inputs

### DIFF
--- a/alz/azuredevops/main.tf
+++ b/alz/azuredevops/main.tf
@@ -12,8 +12,6 @@ module "architecture_definition" {
   source                       = "../../modules/template_architecture_definition"
   starter_module_folder_path   = local.starter_module_folder_path
   architecture_definition_name = local.architecture_definition_name
-  enable_alz                   = var.enable_alz
-  architecture_definition_path = var.architecture_definition_path
 }
 
 module "files" {

--- a/alz/azuredevops/variables.hidden.tf
+++ b/alz/azuredevops/variables.hidden.tf
@@ -351,15 +351,3 @@ variable "role_assignments_bicep" {
     }
   }
 }
-
-variable "architecture_definition_path" {
-  description = "The path to the architecture definition file to use instead of the default"
-  type        = string
-  default     = ""
-}
-
-variable "enable_alz" {
-  description = "Enable the ALZ archetypes in the architecture definition"
-  type        = bool
-  default     = false
-}

--- a/alz/github/main.tf
+++ b/alz/github/main.tf
@@ -12,8 +12,6 @@ module "architecture_definition" {
   source                       = "../../modules/template_architecture_definition"
   starter_module_folder_path   = local.starter_module_folder_path
   architecture_definition_name = local.architecture_definition_name
-  enable_alz                   = var.enable_alz
-  architecture_definition_path = var.architecture_definition_path
 }
 
 module "files" {

--- a/alz/github/variables.hidden.tf
+++ b/alz/github/variables.hidden.tf
@@ -357,15 +357,3 @@ variable "role_assignments_bicep" {
     }
   }
 }
-
-variable "architecture_definition_path" {
-  description = "The path to the architecture definition file to use instead of the default"
-  type        = string
-  default     = ""
-}
-
-variable "enable_alz" {
-  description = "Enable the ALZ archetypes in the architecture definition"
-  type        = bool
-  default     = false
-}

--- a/alz/local/main.tf
+++ b/alz/local/main.tf
@@ -12,8 +12,6 @@ module "architecture_definition" {
   source                       = "../../modules/template_architecture_definition"
   starter_module_folder_path   = local.starter_module_folder_path
   architecture_definition_name = local.architecture_definition_name
-  enable_alz                   = var.enable_alz
-  architecture_definition_path = var.architecture_definition_path
 }
 
 resource "local_file" "architecture_definition_file" {

--- a/alz/local/variables.hidden.tf
+++ b/alz/local/variables.hidden.tf
@@ -274,15 +274,3 @@ variable "role_assignments_bicep" {
     }
   }
 }
-
-variable "architecture_definition_path" {
-  description = "The path to the architecture definition file to use instead of the default"
-  type        = string
-  default     = ""
-}
-
-variable "enable_alz" {
-  description = "Enable the ALZ archetypes in the architecture definition"
-  type        = bool
-  default     = false
-}

--- a/modules/template_architecture_definition/data.tf
+++ b/modules/template_architecture_definition/data.tf
@@ -1,4 +1,4 @@
-data "local_file" "custom_architecture_definition_json" {
-  count    = local.has_custom_architecture_definition ? 1 : 0
-  filename = var.architecture_definition_path
+data "local_file" "architecture_definition_override_json" {
+  count    = local.has_architecture_definition_override ? 1 : 0
+  filename = local.architecture_definition_override_path
 }

--- a/modules/template_architecture_definition/locals.tf
+++ b/modules/template_architecture_definition/locals.tf
@@ -1,13 +1,15 @@
 locals {
+  # Determine template architecture definition inputs from starter module tfvars
+  starter_module_tfvars                 = jsondecode(file("${var.starter_module_folder_path}/terraform.tfvars.json"))
+  default_prefix                        = local.starter_module_tfvars.default_prefix
+  default_postfix                       = local.starter_module_tfvars.default_postfix
+  enable_alz                            = local.starter_module_tfvars.apply_alz_archetypes_via_architecture_definition_template
+  architecture_definition_override_path = local.starter_module_tfvars.architecture_definition_override_path
+  default_template_file_path            = "${var.starter_module_folder_path}/templates/${var.architecture_definition_name}.alz_architecture_definition.json.tftpl"
+  template_file_path                    = local.starter_module_tfvars.architecture_definition_template_path != "" ? local.starter_module_tfvars.architecture_definition_template_path : local.default_template_file_path
+
   # Customer has provided a custom architecture definition
-  has_custom_architecture_definition = var.architecture_definition_path != ""
-
-  # Determine the default prefix and postfix based on the starter module tfvars
-  starter_module_tfvars = jsondecode(file("${var.starter_module_folder_path}/terraform.tfvars.json"))
-  default_prefix        = local.starter_module_tfvars.default_prefix
-  default_postfix       = local.starter_module_tfvars.default_postfix
-
-  template_file_path = "${var.starter_module_folder_path}/lib/templates/${var.architecture_definition_name}.alz_architecture_definition.json.tftpl"
+  has_architecture_definition_override = local.architecture_definition_override_path != ""
 
   slz_architecture_definition_name = "slz"
   fsi_architecture_definition_name = "fsi"
@@ -34,18 +36,18 @@ locals {
   alz_identity       = ["\"identity\""]
 
   # management group layered archetypes
-  root = (var.enable_alz ?
+  root = (local.enable_alz ?
     (var.architecture_definition_name == local.slz_architecture_definition_name ? concat(local.slz_global, local.alz_root) : concat(local.fsi_root, local.alz_root))
   : (var.architecture_definition_name == local.fsi_architecture_definition_name ? local.fsi_root : local.slz_global))
-  platform            = var.enable_alz ? local.alz_platform : []
-  landing_zone        = var.enable_alz ? local.alz_landing_zone : []
-  decommissioned      = var.enable_alz ? local.alz_decommissioned : []
-  sandboxes           = var.enable_alz ? local.alz_sandboxes : []
-  corp                = var.enable_alz ? local.alz_corp : []
-  online              = var.enable_alz ? local.alz_online : []
-  management          = var.enable_alz ? local.alz_management : []
-  connectivity        = var.enable_alz ? local.alz_connectivity : []
-  identity            = var.enable_alz ? local.alz_identity : []
+  platform            = local.enable_alz ? local.alz_platform : []
+  landing_zone        = local.enable_alz ? local.alz_landing_zone : []
+  decommissioned      = local.enable_alz ? local.alz_decommissioned : []
+  sandboxes           = local.enable_alz ? local.alz_sandboxes : []
+  corp                = local.enable_alz ? local.alz_corp : []
+  online              = local.enable_alz ? local.alz_online : []
+  management          = local.enable_alz ? local.alz_management : []
+  connectivity        = local.enable_alz ? local.alz_connectivity : []
+  identity            = local.enable_alz ? local.alz_identity : []
   confidential_corp   = local.confidential
   confidential_online = local.confidential
 

--- a/modules/template_architecture_definition/outputs.tf
+++ b/modules/template_architecture_definition/outputs.tf
@@ -1,3 +1,3 @@
 output "architecture_definition_json" {
-  value = local.has_custom_architecture_definition ? data.local_file.custom_architecture_definition_json[0].content : local.template_file
+  value = local.has_architecture_definition_override ? data.local_file.architecture_definition_override_json[0].content : local.template_file
 }

--- a/modules/template_architecture_definition/variables.tf
+++ b/modules/template_architecture_definition/variables.tf
@@ -7,15 +7,3 @@ variable "architecture_definition_name" {
   type        = string
   description = "Name of the architecture definition"
 }
-
-variable "enable_alz" {
-  description = "Enable the ALZ archetypes in the architecture definition"
-  type        = bool
-  default     = false
-}
-
-variable "architecture_definition_path" {
-  description = "Path to the architecture definition file to use instead of the default"
-  type        = string
-  default     = ""
-}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Adds feature request https://github.com/Azure/ALZ-PowerShell-Module/issues/186

## This PR fixes/adds/changes/removes

1. Uses starter module tfvars for inputs to template architecture definition module
2. Adds input for architecture_definition_template_path
3. Renaming template architecture definition variables, removing from variables.hidden.tf

### Breaking Changes

1. None

## Testing Evidence

![image](https://github.com/user-attachments/assets/6b9b0051-2d2a-4ed5-b233-33f0a833622c)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
