### PR TITLE
fix: Add additional permissions for bicep deployment permissions

### DIFF
--- a/alz/azuredevops/variables.hidden.tf
+++ b/alz/azuredevops/variables.hidden.tf
@@ -223,6 +223,7 @@ variable "custom_role_definitions_bicep" {
           "Microsoft.Management/managementGroups/subscriptions/read",
           "Microsoft.Authorization/policyDefinitions/write",
           "Microsoft.Authorization/policySetDefinitions/write",
+          "Microsoft.Authorization/policyAssignments/write",
           "Microsoft.Authorization/roleDefinitions/write",
           "Microsoft.Authorization/*/read",
           "Microsoft.Resources/deployments/whatIf/action",

--- a/alz/azuredevops/variables.hidden.tf
+++ b/alz/azuredevops/variables.hidden.tf
@@ -231,7 +231,8 @@ variable "custom_role_definitions_bicep" {
           "Microsoft.Resources/deployments/read",
           "Microsoft.Resources/deployments/operationStatuses/read",
           "Microsoft.Authorization/roleAssignments/write",
-          "Microsoft.Authorization/roleAssignments/delete"
+          "Microsoft.Authorization/roleAssignments/delete",
+          "Microsoft.Insights/diagnosticSettings/write"
         ]
         not_actions = []
       }

--- a/alz/github/variables.hidden.tf
+++ b/alz/github/variables.hidden.tf
@@ -229,6 +229,7 @@ variable "custom_role_definitions_bicep" {
           "Microsoft.Management/managementGroups/subscriptions/read",
           "Microsoft.Authorization/policyDefinitions/write",
           "Microsoft.Authorization/policySetDefinitions/write",
+          "Microsoft.Authorization/policyAssignments/write",
           "Microsoft.Authorization/roleDefinitions/write",
           "Microsoft.Authorization/*/read",
           "Microsoft.Resources/deployments/whatIf/action",

--- a/alz/github/variables.hidden.tf
+++ b/alz/github/variables.hidden.tf
@@ -237,7 +237,8 @@ variable "custom_role_definitions_bicep" {
           "Microsoft.Resources/deployments/read",
           "Microsoft.Resources/deployments/operationStatuses/read",
           "Microsoft.Authorization/roleAssignments/write",
-          "Microsoft.Authorization/roleAssignments/delete"
+          "Microsoft.Authorization/roleAssignments/delete",
+          "Microsoft.Insights/diagnosticSettings/write"
         ]
         not_actions = []
       }

--- a/alz/local/variables.hidden.tf
+++ b/alz/local/variables.hidden.tf
@@ -144,6 +144,7 @@ variable "custom_role_definitions_bicep" {
           "Microsoft.Management/managementGroups/subscriptions/read",
           "Microsoft.Authorization/policyDefinitions/write",
           "Microsoft.Authorization/policySetDefinitions/write",
+          "Microsoft.Authorization/policyAssignments/write",
           "Microsoft.Authorization/roleDefinitions/write",
           "Microsoft.Authorization/*/read",
           "Microsoft.Resources/deployments/whatIf/action",

--- a/alz/local/variables.hidden.tf
+++ b/alz/local/variables.hidden.tf
@@ -152,7 +152,8 @@ variable "custom_role_definitions_bicep" {
           "Microsoft.Resources/deployments/read",
           "Microsoft.Resources/deployments/operationStatuses/read",
           "Microsoft.Authorization/roleAssignments/write",
-          "Microsoft.Authorization/roleAssignments/delete"
+          "Microsoft.Authorization/roleAssignments/delete",
+          "Microsoft.Insights/diagnosticSettings/write"
         ]
         not_actions = []
       }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Fixes [#188](https://github.com/Azure/ALZ-PowerShell-Module/issues/188)

## This PR fixes/adds/changes/removes

1. Adds "Microsoft.Insights/diagnosticSettings/write" to mgmt group contributor
2. Adds "Microsoft.Authorization/policyAssignments/write" to mgmt group contributor

### Breaking Changes

1.None

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
