### PR TITLE
fix: Updating confidential archetypes

### DIFF
--- a/modules/template_architecture_definition/locals.tf
+++ b/modules/template_architecture_definition/locals.tf
@@ -48,8 +48,8 @@ locals {
   management          = local.enable_alz ? local.alz_management : []
   connectivity        = local.enable_alz ? local.alz_connectivity : []
   identity            = local.enable_alz ? local.alz_identity : []
-  confidential_corp   = local.confidential
-  confidential_online = local.confidential
+  confidential_corp   = local.enable_alz ? concat(local.confidential, local.alz_corp) : local.confidential
+  confidential_online = local.enable_alz ? concat(local.confidential, local.alz_online) : local.confidential
 
   template_vars = {
     architecture_definition_name            = var.architecture_definition_name


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
Confidential archetypes should contain confidential and optionally the corresponding ALZ archetype

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. confidential online/corp archtypes in architecture defintion module

### Breaking Changes

1. None

## Testing Evidence

![image](https://github.com/user-attachments/assets/6ae66f80-79b9-4738-84af-7731401fedfa)

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
