### PR TITLE
fix: add roles for legacy telemetry provider

### DIFF
--- a/alz/azuredevops/variables.hidden.tf
+++ b/alz/azuredevops/variables.hidden.tf
@@ -197,7 +197,8 @@ variable "custom_role_definitions_terraform" {
           "Microsoft.Management/managementGroups/write",
           "Microsoft.Management/managementGroups/subscriptions/read",
           "Microsoft.Authorization/*/read",
-          "Microsoft.Resources/deployments/write"
+          "Microsoft.Resources/deployments/write",
+          "Microsoft.Resources/deployments/exportTemplate/action"
         ]
         not_actions = []
       }
@@ -210,7 +211,8 @@ variable "custom_role_definitions_terraform" {
           "Microsoft.Management/managementGroups/read",
           "Microsoft.Management/managementGroups/subscriptions/read",
           "Microsoft.Authorization/*/read",
-          "Microsoft.Resources/deployments/write"
+          "Microsoft.Resources/deployments/write",
+          "Microsoft.Resources/deployments/exportTemplate/action"
         ]
         not_actions = []
       }
@@ -221,7 +223,8 @@ variable "custom_role_definitions_terraform" {
       permissions = {
         actions = [
           "*",
-          "Microsoft.Resources/deployments/write"
+          "Microsoft.Resources/deployments/write",
+          "Microsoft.Resources/deployments/exportTemplate/action"
         ]
         not_actions = []
       }
@@ -232,7 +235,8 @@ variable "custom_role_definitions_terraform" {
       permissions = {
         actions = [
           "*/read",
-          "Microsoft.Resources/deployments/write"
+          "Microsoft.Resources/deployments/write",
+          "Microsoft.Resources/deployments/exportTemplate/action"
         ]
         not_actions = []
       }

--- a/alz/github/variables.hidden.tf
+++ b/alz/github/variables.hidden.tf
@@ -197,7 +197,8 @@ variable "custom_role_definitions_terraform" {
           "Microsoft.Management/managementGroups/write",
           "Microsoft.Management/managementGroups/subscriptions/read",
           "Microsoft.Authorization/*/read",
-          "Microsoft.Resources/deployments/write"
+          "Microsoft.Resources/deployments/write",
+          "Microsoft.Resources/deployments/exportTemplate/action"
         ]
         not_actions = []
       }
@@ -210,7 +211,8 @@ variable "custom_role_definitions_terraform" {
           "Microsoft.Management/managementGroups/read",
           "Microsoft.Management/managementGroups/subscriptions/read",
           "Microsoft.Authorization/*/read",
-          "Microsoft.Resources/deployments/write"
+          "Microsoft.Resources/deployments/write",
+          "Microsoft.Resources/deployments/exportTemplate/action"
         ]
         not_actions = []
       }
@@ -221,7 +223,8 @@ variable "custom_role_definitions_terraform" {
       permissions = {
         actions = [
           "*",
-          "Microsoft.Resources/deployments/write"
+          "Microsoft.Resources/deployments/write",
+          "Microsoft.Resources/deployments/exportTemplate/action"
         ]
         not_actions = []
       }
@@ -232,7 +235,8 @@ variable "custom_role_definitions_terraform" {
       permissions = {
         actions = [
           "*/read",
-          "Microsoft.Resources/deployments/write"
+          "Microsoft.Resources/deployments/write",
+          "Microsoft.Resources/deployments/exportTemplate/action"
         ]
         not_actions = []
       }

--- a/alz/local/variables.hidden.tf
+++ b/alz/local/variables.hidden.tf
@@ -86,7 +86,8 @@ variable "custom_role_definitions_terraform" {
           "Microsoft.Management/managementGroups/write",
           "Microsoft.Management/managementGroups/subscriptions/read",
           "Microsoft.Authorization/*/read",
-          "Microsoft.Resources/deployments/write"
+          "Microsoft.Resources/deployments/write",
+          "Microsoft.Resources/deployments/exportTemplate/action"
         ]
         not_actions = []
       }
@@ -99,7 +100,8 @@ variable "custom_role_definitions_terraform" {
           "Microsoft.Management/managementGroups/read",
           "Microsoft.Management/managementGroups/subscriptions/read",
           "Microsoft.Authorization/*/read",
-          "Microsoft.Resources/deployments/write"
+          "Microsoft.Resources/deployments/write",
+          "Microsoft.Resources/deployments/exportTemplate/action"
         ]
         not_actions = []
       }
@@ -110,7 +112,8 @@ variable "custom_role_definitions_terraform" {
       permissions = {
         actions = [
           "*",
-          "Microsoft.Resources/deployments/write"
+          "Microsoft.Resources/deployments/write",
+          "Microsoft.Resources/deployments/exportTemplate/action"
         ]
         not_actions = []
       }
@@ -121,7 +124,8 @@ variable "custom_role_definitions_terraform" {
       permissions = {
         actions = [
           "*/read",
-          "Microsoft.Resources/deployments/write"
+          "Microsoft.Resources/deployments/write",
+          "Microsoft.Resources/deployments/exportTemplate/action"
         ]
         not_actions = []
       }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Add permissions required to read a deployment template for the legacy telemetry provider

## This PR fixes/adds/changes/removes

1. https://github.com/Azure/ALZ-PowerShell-Module/issues/241

### Breaking Changes

None

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
