### PR TITLE
fix: pin azure devops provider version

### DIFF
--- a/.github/workflows/docs-fmt-test.yml
+++ b/.github/workflows/docs-fmt-test.yml
@@ -25,6 +25,12 @@ jobs:
           go-version: '1.20.x'
           cache-dependency-path: tests/go.sum
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: latest
+          terraform_wrapper: false
+
       - name: Install tools
         run: make tools
 

--- a/alz/azuredevops/terraform.tf
+++ b/alz/azuredevops/terraform.tf
@@ -11,7 +11,7 @@ terraform {
     }
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "~> 1.1"
+      version = "1.4"
     }
     random = {
       source  = "hashicorp/random"

--- a/alz/azuredevops/terraform.tf
+++ b/alz/azuredevops/terraform.tf
@@ -38,4 +38,3 @@ provider "azuredevops" {
   personal_access_token = var.azure_devops_personal_access_token
   org_service_url       = module.azure_devops.organization_url
 }
-

--- a/modules/azure_devops/terraform.tf
+++ b/modules/azure_devops/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "~> 1.1"
+      version = "1.4"
     }
   }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This is a workaround for a breaking change in 1.5 of the azuredevops provider.

## This PR fixes/adds/changes/removes

- https://github.com/Azure/ALZ-PowerShell-Module/issues/266

### Breaking Changes

None

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
