### PR TITLE
feat: update default_postfix to optional_postfix

### DIFF
--- a/modules/template_architecture_definition/locals.tf
+++ b/modules/template_architecture_definition/locals.tf
@@ -2,7 +2,7 @@ locals {
   # Determine template architecture definition inputs from starter module tfvars
   starter_module_tfvars                  = jsondecode(file("${var.starter_module_folder_path}/terraform.tfvars.json"))
   default_prefix                         = try(local.starter_module_tfvars.default_prefix, "alz")
-  default_postfix                        = try(local.starter_module_tfvars.default_postfix, "")
+  optional_postfix                       = try(local.starter_module_tfvars.optional_postfix, "")
   management_group_configuration         = try(local.starter_module_tfvars.management_group_configuration, {})
   platform_management_group_children     = try(local.starter_module_tfvars.platform_management_group_children, {})
   landing_zone_management_group_children = try(local.starter_module_tfvars.landing_zone_management_group_children, {})
@@ -54,7 +54,7 @@ locals {
 
   management_group_format_variables = {
     default_prefix  = local.default_prefix
-    default_postfix = local.default_postfix
+    optional_postfix = local.optional_postfix
   }
 
   root_management_group_id                = try(templatestring(local.management_group_configuration.root.id, local.management_group_format_variables), "")

--- a/modules/template_architecture_definition/locals.tf
+++ b/modules/template_architecture_definition/locals.tf
@@ -53,7 +53,7 @@ locals {
   confidential_online_archtypes = var.apply_alz_archetypes_via_architecture_definition_template ? concat(local.alz_online_archtype, local.config_confidential_online_archtypes) : local.config_confidential_online_archtypes
 
   management_group_format_variables = {
-    default_prefix  = local.default_prefix
+    default_prefix   = local.default_prefix
     optional_postfix = local.optional_postfix
   }
 


### PR DESCRIPTION
## Overview/Summary

Update starter module default_postfix to optional_postfix as there is confusion between the default_postfix and postfix_number. Want to update to remove the confusion between the two.

## This PR fixes/adds/changes/removes

1. [Update default_postfix to optional_postfix](https://github.com/Azure/Azure-Landing-Zones/issues/2571)

### Breaking Changes

1. Breaks previous versions of FSI/SLZ starter module using default_postfix

## Testing Evidence

In progress...

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
