### PR TITLE
fix: temporary allow reader access to storage account for 1.11 permissions issue

### DIFF
--- a/alz/azuredevops/pipelines/terraform/main/cd.yaml
+++ b/alz/azuredevops/pipelines/terraform/main/cd.yaml
@@ -21,7 +21,7 @@ parameters:
   - name: terraform_cli_version
     displayName: Terraform CLI Version
     type: string
-    default: '1.10.5'
+    default: 'latest'
 
 lockBehavior: sequential
 

--- a/alz/azuredevops/pipelines/terraform/main/cd.yaml
+++ b/alz/azuredevops/pipelines/terraform/main/cd.yaml
@@ -18,6 +18,10 @@ parameters:
     values:
       - 'apply'
       - 'destroy'
+  - name: terraform_cli_version
+    displayName: Terraform CLI Version
+    type: string
+    default: '1.10.5'
 
 lockBehavior: sequential
 
@@ -26,3 +30,4 @@ extends:
   parameters:
     terraform_action: $${{ parameters.terraform_action }}
     root_module_folder_relative_path: ${root_module_folder_relative_path}
+    terraform_cli_version: $${{ coalesce(parameters.terraform_cli_version, 'latest') }}

--- a/alz/azuredevops/pipelines/terraform/main/ci.yaml
+++ b/alz/azuredevops/pipelines/terraform/main/ci.yaml
@@ -12,7 +12,7 @@ parameters:
   - name: terraform_cli_version
     displayName: Terraform CLI Version
     type: string
-    default: '1.10.5'
+    default: 'latest'
 
 lockBehavior: sequential
 

--- a/alz/azuredevops/pipelines/terraform/main/ci.yaml
+++ b/alz/azuredevops/pipelines/terraform/main/ci.yaml
@@ -8,9 +8,16 @@ resources:
       type: git
       name: ${project_name}/${repository_name_templates}
 
+parameters:
+  - name: terraform_cli_version
+    displayName: Terraform CLI Version
+    type: string
+    default: '1.10.5'
+
 lockBehavior: sequential
 
 extends:
   template: ${ci_template_path}@templates
   parameters:
     root_module_folder_relative_path: ${root_module_folder_relative_path}
+    terraform_cli_version: $${{ coalesce(parameters.terraform_cli_version, 'latest') }}

--- a/alz/azuredevops/pipelines/terraform/templates/cd-template.yaml
+++ b/alz/azuredevops/pipelines/terraform/templates/cd-template.yaml
@@ -27,7 +27,7 @@ stages:
                   displayName: Checkout Terraform Module
                 - template: helpers/terraform-installer.yaml
                   parameters:
-                    terraformVersion: 'latest'
+                    terraformVersion: '1.10.5'
                 - template: helpers/terraform-init.yaml
                   parameters:
                     serviceConnection: '${service_connection_name_plan}'
@@ -94,7 +94,7 @@ stages:
                     targetPath: '$(Build.SourcesDirectory)'
                 - template: helpers/terraform-installer.yaml
                   parameters:
-                    terraformVersion: 'latest'
+                    terraformVersion: '1.10.5'
                 - template: helpers/terraform-init.yaml
                   parameters:
                     serviceConnection: '${service_connection_name_apply}'

--- a/alz/azuredevops/pipelines/terraform/templates/cd-template.yaml
+++ b/alz/azuredevops/pipelines/terraform/templates/cd-template.yaml
@@ -4,6 +4,8 @@ parameters:
     default: 'apply'
   - name: root_module_folder_relative_path
     default: '.'
+  - name: terraform_cli_version
+    default: 'latest'
 
 stages:
   - stage: plan
@@ -27,7 +29,7 @@ stages:
                   displayName: Checkout Terraform Module
                 - template: helpers/terraform-installer.yaml
                   parameters:
-                    terraformVersion: '1.10.5'
+                    terraformVersion: $${{ parameters.terraform_cli_version }}
                 - template: helpers/terraform-init.yaml
                   parameters:
                     serviceConnection: '${service_connection_name_plan}'
@@ -94,7 +96,7 @@ stages:
                     targetPath: '$(Build.SourcesDirectory)'
                 - template: helpers/terraform-installer.yaml
                   parameters:
-                    terraformVersion: '1.10.5'
+                    terraformVersion: $${{ parameters.terraform_cli_version }}
                 - template: helpers/terraform-init.yaml
                   parameters:
                     serviceConnection: '${service_connection_name_apply}'

--- a/alz/azuredevops/pipelines/terraform/templates/ci-template.yaml
+++ b/alz/azuredevops/pipelines/terraform/templates/ci-template.yaml
@@ -18,7 +18,7 @@ stages:
         steps:
           - template: helpers/terraform-installer.yaml
             parameters:
-              terraformVersion: 'latest'
+              terraformVersion: '1.10.5'
           - pwsh: |
               terraform `
               -chdir="$${{ parameters.root_module_folder_relative_path }}" `
@@ -51,7 +51,7 @@ stages:
                   displayName: Checkout Terraform Module
                 - template: helpers/terraform-installer.yaml
                   parameters:
-                    terraformVersion: 'latest'
+                    terraformVersion: '1.10.5'
                 - template: helpers/terraform-init.yaml
                   parameters:
                     serviceConnection: '${service_connection_name_plan}'

--- a/alz/azuredevops/pipelines/terraform/templates/ci-template.yaml
+++ b/alz/azuredevops/pipelines/terraform/templates/ci-template.yaml
@@ -2,6 +2,8 @@
 parameters:
   - name: root_module_folder_relative_path
     default: '.'
+  - name: terraform_cli_version
+    default: 'latest'
 
 stages:
   - stage: validate
@@ -18,7 +20,7 @@ stages:
         steps:
           - template: helpers/terraform-installer.yaml
             parameters:
-              terraformVersion: '1.10.5'
+              terraformVersion: $${{ parameters.terraform_cli_version }}
           - pwsh: |
               terraform `
               -chdir="$${{ parameters.root_module_folder_relative_path }}" `
@@ -51,7 +53,7 @@ stages:
                   displayName: Checkout Terraform Module
                 - template: helpers/terraform-installer.yaml
                   parameters:
-                    terraformVersion: '1.10.5'
+                    terraformVersion: $${{ parameters.terraform_cli_version }}
                 - template: helpers/terraform-init.yaml
                   parameters:
                     serviceConnection: '${service_connection_name_plan}'

--- a/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-installer.yaml
+++ b/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-installer.yaml
@@ -23,7 +23,7 @@ steps:
           if($versionResponse.StatusCode -ne "200") {
               throw "Unable to query Terraform version, please check the supplied version and try again..."
           }
-          $release = ($versionResponse).Content
+          $release = ($versionResponse).Content | ConvertFrom-Json
       }
 
       $commandDetails = Get-Command -Name terraform -ErrorAction SilentlyContinue

--- a/alz/github/actions/terraform/main/workflows/cd.yaml
+++ b/alz/github/actions/terraform/main/workflows/cd.yaml
@@ -14,6 +14,11 @@ on:
         options:
           - 'apply'
           - 'destroy'
+      terraform_cli_version:
+        description: 'Terraform CLI Version'
+        required: true
+        default: '1.10.5'
+        type: string
 
 jobs:
   plan_and_apply:
@@ -25,3 +30,4 @@ jobs:
     with:
       terraform_action: $${{ inputs.terraform_action }}
       root_module_folder_relative_path: '${root_module_folder_relative_path}'
+      terraform_cli_version: $${{ inputs.terraform_cli_version }}

--- a/alz/github/actions/terraform/main/workflows/cd.yaml
+++ b/alz/github/actions/terraform/main/workflows/cd.yaml
@@ -17,7 +17,7 @@ on:
       terraform_cli_version:
         description: 'Terraform CLI Version'
         required: true
-        default: '1.10.5'
+        default: 'latest'
         type: string
 
 jobs:

--- a/alz/github/actions/terraform/main/workflows/ci.yaml
+++ b/alz/github/actions/terraform/main/workflows/ci.yaml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      terraform_cli_version:
+        description: 'Terraform CLI Version'
+        required: true
+        default: '1.10.5'
+        type: string
 
 jobs:
   validate_and_plan:
@@ -16,3 +22,4 @@ jobs:
       pull-requests: write
     with:
       root_module_folder_relative_path: '${root_module_folder_relative_path}'
+      terraform_cli_version: $${{ inputs.terraform_cli_version }}

--- a/alz/github/actions/terraform/main/workflows/ci.yaml
+++ b/alz/github/actions/terraform/main/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
       terraform_cli_version:
         description: 'Terraform CLI Version'
         required: true
-        default: '1.10.5'
+        default: 'latest'
         type: string
 
 jobs:

--- a/alz/github/actions/terraform/templates/workflows/cd-template.yaml
+++ b/alz/github/actions/terraform/templates/workflows/cd-template.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
+          terraform_version: "1.10.5"
 
       - name: Terraform Init
         run: |
@@ -113,6 +114,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
+          terraform_version: "1.10.5"
 
       - name: Terraform Init
         run: |

--- a/alz/github/actions/terraform/templates/workflows/cd-template.yaml
+++ b/alz/github/actions/terraform/templates/workflows/cd-template.yaml
@@ -11,6 +11,10 @@ on:
         description: 'Root Module Folder Relative Path'
         default: '.'
         type: string
+      terraform_cli_version:
+        description: 'Terraform CLI Version'
+        default: 'latest'
+        type: string
 
 jobs:
   plan:
@@ -37,7 +41,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
-          terraform_version: "1.10.5"
+          terraform_version: $${{ inputs.terraform_cli_versions }}
 
       - name: Terraform Init
         run: |
@@ -114,7 +118,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
-          terraform_version: "1.10.5"
+          terraform_version: $${{ inputs.terraform_cli_versions }}
 
       - name: Terraform Init
         run: |

--- a/alz/github/actions/terraform/templates/workflows/ci-template.yaml
+++ b/alz/github/actions/terraform/templates/workflows/ci-template.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
+          terraform_version: "1.10.5"
 
       - name: Terraform Format Check
         run: |
@@ -72,6 +73,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
+          terraform_version: "1.10.5"
 
       - name: Terraform Init
         run: |

--- a/alz/github/actions/terraform/templates/workflows/ci-template.yaml
+++ b/alz/github/actions/terraform/templates/workflows/ci-template.yaml
@@ -7,6 +7,10 @@ on:
         description: 'Root Module Folder Relative Path'
         default: '.'
         type: string
+      terraform_cli_version:
+        description: 'Terraform CLI Version'
+        default: 'latest'
+        type: string
 
 jobs:
   validate:
@@ -22,7 +26,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
-          terraform_version: "1.10.5"
+          terraform_version: $${{ inputs.terraform_cli_versions }}
 
       - name: Terraform Format Check
         run: |
@@ -73,7 +77,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
-          terraform_version: "1.10.5"
+          terraform_version: $${{ inputs.terraform_cli_versions }}
 
       - name: Terraform Init
         run: |

--- a/modules/azure/storage.tf
+++ b/modules/azure/storage.tf
@@ -55,3 +55,19 @@ resource "azurerm_role_assignment" "alz_storage_container_additional" {
   role_definition_name = "Storage Blob Data Owner"
   principal_id         = each.value
 }
+
+# These role assignments are a temporary addition to handle this issue in the Terraform CLI: https://github.com/hashicorp/terraform/issues/36595
+# They will be removed once the issue has been resolved
+resource "azurerm_role_assignment" "alz_storage_reader" {
+  for_each             = var.create_storage_account ? var.user_assigned_managed_identities : {}
+  scope                = azurerm_storage_account.alz[0].id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_user_assigned_identity.alz[each.key].principal_id
+}
+
+resource "azurerm_role_assignment" "alz_storage_reader_additional" {
+  for_each             = var.create_storage_account ? var.additional_role_assignment_principal_ids : {}
+  scope                = azurerm_storage_account.alz[0].id
+  role_definition_name = "Reader"
+  principal_id         = each.value
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

1.11 of Terraform Core introduced a breaking change to the azurerm backend. https://github.com/hashicorp/terraform/issues/36595

Adding the ability to override the Terraform CLI version for easy testing. 

Temporarily granting reader access to the storage account.

## This PR fixes/adds/changes/removes

None

### Breaking Changes

None

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
