### PR TITLE
feat: Fix path for architecture_definition_file

### DIFF
--- a/alz/azuredevops/locals.files.tf
+++ b/alz/azuredevops/locals.files.tf
@@ -86,7 +86,7 @@ locals {
   }
 
   architecture_definition_file = local.has_architecture_definition ? {
-    "${local.target_folder_name}/${var.root_module_folder_relative_path}/lib/architecture_definitions/${local.architecture_definition_name}.alz_architecture_definition.json" = {
+    "${local.starter_root_module_folder_path}/lib/architecture_definitions/${local.architecture_definition_name}.alz_architecture_definition.json" = {
       content = module.architecture_definition[0].architecture_definition_json
     }
   } : {}

--- a/alz/azuredevops/locals.files.tf
+++ b/alz/azuredevops/locals.files.tf
@@ -86,7 +86,7 @@ locals {
   }
 
   architecture_definition_file = local.has_architecture_definition ? {
-    "${local.starter_root_module_folder_path}/lib/architecture_definitions/${local.architecture_definition_name}.alz_architecture_definition.json" = {
+    "${var.root_module_folder_relative_path}/lib/architecture_definitions/${local.architecture_definition_name}.alz_architecture_definition.json" = {
       content = module.architecture_definition[0].architecture_definition_json
     }
   } : {}

--- a/alz/azuredevops/locals.files.tf
+++ b/alz/azuredevops/locals.files.tf
@@ -86,7 +86,7 @@ locals {
   }
 
   architecture_definition_file = local.has_architecture_definition ? {
-    "lib/architecture_definitions/${local.architecture_definition_name}.alz_architecture_definition.json" = {
+    "${local.target_folder_name}/${var.root_module_folder_relative_path}/lib/architecture_definitions/${local.architecture_definition_name}.alz_architecture_definition.json" = {
       content = module.architecture_definition[0].architecture_definition_json
     }
   } : {}

--- a/alz/github/locals.files.tf
+++ b/alz/github/locals.files.tf
@@ -84,7 +84,7 @@ locals {
   }
 
   architecture_definition_file = local.has_architecture_definition ? {
-    "lib/architecture_definitions/${local.architecture_definition_name}.alz_architecture_definition.json" = {
+    "${local.target_folder_name}/${var.root_module_folder_relative_path}/lib/architecture_definitions/${local.architecture_definition_name}.alz_architecture_definition.json" = {
       content = module.architecture_definition[0].architecture_definition_json
     }
   } : {}

--- a/alz/github/locals.files.tf
+++ b/alz/github/locals.files.tf
@@ -84,7 +84,7 @@ locals {
   }
 
   architecture_definition_file = local.has_architecture_definition ? {
-    "${local.starter_root_module_folder_path}/lib/architecture_definitions/${local.architecture_definition_name}.alz_architecture_definition.json" = {
+    "${var.root_module_folder_relative_path}/lib/architecture_definitions/${local.architecture_definition_name}.alz_architecture_definition.json" = {
       content = module.architecture_definition[0].architecture_definition_json
     }
   } : {}

--- a/alz/github/locals.files.tf
+++ b/alz/github/locals.files.tf
@@ -84,7 +84,7 @@ locals {
   }
 
   architecture_definition_file = local.has_architecture_definition ? {
-    "${local.target_folder_name}/${var.root_module_folder_relative_path}/lib/architecture_definitions/${local.architecture_definition_name}.alz_architecture_definition.json" = {
+    "${local.starter_root_module_folder_path}/lib/architecture_definitions/${local.architecture_definition_name}.alz_architecture_definition.json" = {
       content = module.architecture_definition[0].architecture_definition_json
     }
   } : {}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Update the path to the `architecture_definition_file` to be created under `<module_path>/lib`

## This PR fixes/adds/changes/removes

1. [Bug: Azure DevOps terraform provider ALZ fails to load custom_url from /lib](https://github.com/Azure/ALZ-PowerShell-Module/issues/316)

### Breaking Changes

N/A

## Testing Evidence

In progress

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
