### PR TITLE
add the migrate state flag if using remote state

### DIFF
--- a/alz/local/templates/terraform-deploy-local.ps1
+++ b/alz/local/templates/terraform-deploy-local.ps1
@@ -34,6 +34,7 @@ $arguments = @()
 $arguments += "-chdir=$root_module_folder_relative_path"
 $arguments += "init"
 if($use_remote_state) {
+  $arguments += "-migrate-state"
   $arguments += "-backend-config=resource_group_name=$remote_state_resource_group_name"
   $arguments += "-backend-config=storage_account_name=$remote_state_storage_account_name"
   $arguments += "-backend-config=container_name=$remote_state_storage_container_name"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Deploying locally.
Terraform IaC.

If a user deploys SLZ with the create_bootstrap_resources_in_azure flag in inputs.yaml set to false, it creates tf state locally. So far so good. 

But what if they wanted remote state? 

Best way forward would be:

1. set create_bootstrap_resources_in_azure = true in inputs.yaml
2. rerun deploy-accelerator
3. rerun deploy-local.ps1
4. state gets migrated automatically

State migration isn't handled currently. This PR seeks to add this capability.

## This PR fixes/adds/changes/removes

1. add -migrate-state to tf init in deploy-local.ps1 if use_remote_state is detected

### Breaking Changes
none

## Testing Evidence

I tested according to the description above 2 use cases:
1. a first run through where use_remote_state is detected for the first time. state is migrated correctly.
2. on the second run through after state has been migrated. The -migrate-state setting is correctly ignored because there is no local state to migrate.

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [X] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
