### PR TITLE
feat: add the migrate state flag if using remote state

### DIFF
--- a/alz/local/templates/terraform-deploy-local.ps1
+++ b/alz/local/templates/terraform-deploy-local.ps1
@@ -34,6 +34,7 @@ $arguments = @()
 $arguments += "-chdir=$root_module_folder_relative_path"
 $arguments += "init"
 if($use_remote_state) {
+  $arguments += "-migrate-state"
   $arguments += "-backend-config=resource_group_name=$remote_state_resource_group_name"
   $arguments += "-backend-config=storage_account_name=$remote_state_storage_account_name"
   $arguments += "-backend-config=container_name=$remote_state_storage_container_name"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

IaC: terraform
Starter module: SLZ
Deploying locally.

If a user first installs with inputs.yaml/create_bootstrap_resources_in_azure = false - in error - and then later decides to set that flag to true, the local tf state should be migrated to remote state.

## This PR fixes/adds/changes/removes

1. Adds -migrate-state flag to the tf init step in deploy-local.ps1 if use_remote_state is detected

### Breaking Changes

None

## Testing Evidence

I tested 2 use cases:
1. first run after a local deployment where local state exists and remote state settings are detected. It correctly migrates the state to remote backend.
2. second run once the state has been migrated. It correctly ignores the -migrate-state flag.

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure. (cannot add issue - no templates)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation. (did not find any relevant docs to update)
