### PR TITLE
feat: enable configuration of repository visibility

### DIFF
--- a/alz/github/main.tf
+++ b/alz/github/main.tf
@@ -78,6 +78,7 @@ module "github" {
   organization_name                            = var.github_organization_name
   environments                                 = local.environments
   repository_name                              = local.resource_names.version_control_system_repository
+  repository_visibility                        = var.repository_visibility
   use_template_repository                      = var.use_separate_repository_for_templates
   repository_name_templates                    = local.resource_names.version_control_system_repository_templates
   repository_files                             = local.repository_files

--- a/alz/github/variables.tf
+++ b/alz/github/variables.tf
@@ -87,6 +87,16 @@ variable "use_separate_repository_for_templates" {
   default     = true
 }
 
+variable "repository_visibility" {
+  description = "Can be public or private. If your organization is associated with an enterprise account using GitHub Enterprise Cloud or GitHub Enterprise Server 2.20+, visibility can also be internal. The visibility parameter overrides the private parameter."
+  type        = string
+  default     = "private"
+  validation {
+    condition     = contains(["private", "public", "internal"], var.repository_visibility)
+    error_message = "The repository visibility must be either of (private|public|internal)"
+  }
+}
+
 variable "bootstrap_subscription_id" {
   description = "Azure Subscription ID for the bootstrap resources (e.g. storage account, identities, etc). Leave empty to use the az login subscription"
   type        = string

--- a/modules/github/repository_module.tf
+++ b/modules/github/repository_module.tf
@@ -2,7 +2,7 @@ resource "github_repository" "alz" {
   name                 = var.repository_name
   description          = var.repository_name
   auto_init            = true
-  visibility           = data.github_organization.alz.plan == local.free_plan ? "public" : "private"
+  visibility           = var.repository_visibility
   allow_update_branch  = true
   allow_merge_commit   = false
   allow_rebase_merge   = false

--- a/modules/github/repository_templates.tf
+++ b/modules/github/repository_templates.tf
@@ -3,7 +3,7 @@ resource "github_repository" "alz_templates" {
   name                 = var.repository_name_templates
   description          = var.repository_name_templates
   auto_init            = true
-  visibility           = data.github_organization.alz.plan == local.free_plan ? "public" : "private"
+  visibility           = var.repository_visibility
   allow_update_branch  = true
   allow_merge_commit   = false
   allow_rebase_merge   = false

--- a/modules/github/variables.tf
+++ b/modules/github/variables.tf
@@ -91,3 +91,12 @@ variable "use_self_hosted_runners" {
 variable "create_branch_policies" {
   type = bool
 }
+
+variable "repository_visibility" {
+  type    = string
+  default = "private"
+  validation {
+    condition     = contains(["private", "public", "internal"], var.repository_visibility)
+    error_message = "The repository visibility must be either of (private|public|internal)"
+  }
+}

--- a/modules/github/variables.tf
+++ b/modules/github/variables.tf
@@ -93,10 +93,5 @@ variable "create_branch_policies" {
 }
 
 variable "repository_visibility" {
-  type    = string
-  default = "private"
-  validation {
-    condition     = contains(["private", "public", "internal"], var.repository_visibility)
-    error_message = "The repository visibility must be either of (private|public|internal)"
-  }
+  type = string
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This pull request enables the configuration of GitHub repository visibility via a new configuration parameter `repository_visibility`. This allows users to set the visibility to either `private`, `public` or `internal` explicitly.

The current implementation defaults to public visibility if the organization has the free plan. Which you may not want out of the box. 

For reference, GitHub supports private repositories for any plan.
![image](https://github.com/user-attachments/assets/4862fb89-dfd5-4587-b489-0f9c42bb7427)


## This PR fixes/adds/changes/removes

1. Adds a new configuration parameter `repository_visibility`
2. Defaults `repository_visibility` to private

### Breaking Changes

1. Default value for `repository_visibility` is set to `private` for _any_ plan. So GitHub Users/Organizations with the free plan changes from `public` to `private`.

## Testing Evidence

When testing, I ran the bootstrap procedure 4 times (using ALZ-PowerShell-Module). On each run I set `repository_visibility` to: `private|public|internal` and lastly commented it completely out (from input-github.yaml). Once the first `terraform plan` was finished I confirmed with the plan output (`tfplan`) and `terraform.tfvars.json` that it would create the GitHub repositories with `repository_visibility` set to the configured value.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
