### PR TITLE
feat: remove storage account replication validation

### DIFF
--- a/alz/azuredevops/variables.tf
+++ b/alz/azuredevops/variables.tf
@@ -343,10 +343,6 @@ variable "storage_account_replication_type" {
   description = "Controls the redundancy for the storage account"
   type        = string
   default     = "ZRS"
-  validation {
-    condition     = var.storage_account_replication_type == "ZRS" || var.storage_account_replication_type == "GZRS" || var.storage_account_replication_type == "RAGZRS"
-    error_message = "Invalid storage account replication type. Valid values are ZRS, GZRS and RAGZRS."
-  }
 }
 
 variable "bicep_config_file_path" {

--- a/alz/github/variables.tf
+++ b/alz/github/variables.tf
@@ -332,10 +332,6 @@ variable "storage_account_replication_type" {
   description = "Controls the redundancy for the storage account"
   type        = string
   default     = "ZRS"
-  validation {
-    condition     = var.storage_account_replication_type == "ZRS" || var.storage_account_replication_type == "GZRS" || var.storage_account_replication_type == "RAGZRS"
-    error_message = "Invalid storage account replication type. Valid values are ZRS, GZRS and RAGZRS."
-  }
 }
 
 variable "bicep_config_file_path" {

--- a/alz/local/variables.tf
+++ b/alz/local/variables.tf
@@ -184,10 +184,6 @@ variable "storage_account_replication_type" {
   description = "Controls the redundancy for the storage account"
   type        = string
   default     = "ZRS"
-  validation {
-    condition     = var.storage_account_replication_type == "ZRS" || var.storage_account_replication_type == "GZRS" || var.storage_account_replication_type == "RAGZRS"
-    error_message = "Invalid storage account replication type. Valid values are ZRS, GZRS and RAGZRS."
-  }
 }
 
 variable "custom_role_definitions_terraform" {

--- a/modules/azure/variables.tf
+++ b/modules/azure/variables.tf
@@ -50,10 +50,6 @@ variable "storage_container_name" {
 variable "storage_account_replication_type" {
   type    = string
   default = "ZRS"
-  validation {
-    condition     = var.storage_account_replication_type == "ZRS" || var.storage_account_replication_type == "GZRS" || var.storage_account_replication_type == "RAGZRS"
-    error_message = "Invalid storage account replication type. Valid values are LRS, GZRS and RAGZRS."
-  }
 }
 
 variable "agent_container_instances" {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Remove the storage account replication validation and just default tom ZRS. This is to support regions with no AZ support for storage, such as Canada East.

## This PR fixes/adds/changes/removes

N/A

### Breaking Changes

None

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
