### PR TITLE
feat(alz/azuredevops): update ALZ management group RBAC role definitions

### DIFF
--- a/alz/azuredevops/variables.tf
+++ b/alz/azuredevops/variables.tf
@@ -377,6 +377,9 @@ variable "custom_role_definitions_terraform" {
           "Microsoft.Management/managementGroups/subscriptions/write",
           "Microsoft.Management/managementGroups/write",
           "Microsoft.Management/managementGroups/subscriptions/read",
+          "Microsoft.Management/managementGroups/settings/read",
+          "Microsoft.Management/managementGroups/settings/write",
+          "Microsoft.Management/managementGroups/settings/delete",
           "Microsoft.Authorization/*/read",
           "Microsoft.Resources/deployments/write",
           "Microsoft.Resources/deployments/exportTemplate/action"
@@ -391,6 +394,7 @@ variable "custom_role_definitions_terraform" {
         actions = [
           "Microsoft.Management/managementGroups/read",
           "Microsoft.Management/managementGroups/subscriptions/read",
+          "Microsoft.Management/managementGroups/settings/read",
           "Microsoft.Authorization/*/read",
           "Microsoft.Resources/deployments/write",
           "Microsoft.Resources/deployments/exportTemplate/action"
@@ -447,6 +451,9 @@ variable "custom_role_definitions_bicep" {
           "Microsoft.Management/managementGroups/subscriptions/write",
           "Microsoft.Management/managementGroups/write",
           "Microsoft.Management/managementGroups/subscriptions/read",
+          "Microsoft.Management/managementGroups/settings/read",
+          "Microsoft.Management/managementGroups/settings/write",
+          "Microsoft.Management/managementGroups/settings/delete",
           "Microsoft.Authorization/policyDefinitions/write",
           "Microsoft.Authorization/policySetDefinitions/write",
           "Microsoft.Authorization/policyAssignments/write",
@@ -471,6 +478,7 @@ variable "custom_role_definitions_bicep" {
         actions = [
           "Microsoft.Management/managementGroups/read",
           "Microsoft.Management/managementGroups/subscriptions/read",
+          "Microsoft.Management/managementGroups/settings/read",
           "Microsoft.Authorization/*/read",
           "Microsoft.Authorization/policyDefinitions/write",
           "Microsoft.Authorization/policySetDefinitions/write",

--- a/alz/github/variables.tf
+++ b/alz/github/variables.tf
@@ -398,6 +398,9 @@ variable "custom_role_definitions_terraform" {
           "Microsoft.Management/managementGroups/read",
           "Microsoft.Management/managementGroups/subscriptions/delete",
           "Microsoft.Management/managementGroups/subscriptions/write",
+          "Microsoft.Management/managementGroups/settings/read",
+          "Microsoft.Management/managementGroups/settings/write",
+          "Microsoft.Management/managementGroups/settings/delete",
           "Microsoft.Management/managementGroups/write",
           "Microsoft.Management/managementGroups/subscriptions/read",
           "Microsoft.Authorization/*/read",
@@ -414,6 +417,7 @@ variable "custom_role_definitions_terraform" {
         actions = [
           "Microsoft.Management/managementGroups/read",
           "Microsoft.Management/managementGroups/subscriptions/read",
+          "Microsoft.Management/managementGroups/settings/read",
           "Microsoft.Authorization/*/read",
           "Microsoft.Resources/deployments/write",
           "Microsoft.Resources/deployments/exportTemplate/action"
@@ -468,6 +472,9 @@ variable "custom_role_definitions_bicep" {
           "Microsoft.Management/managementGroups/read",
           "Microsoft.Management/managementGroups/subscriptions/delete",
           "Microsoft.Management/managementGroups/subscriptions/write",
+          "Microsoft.Management/managementGroups/settings/read",
+          "Microsoft.Management/managementGroups/settings/write",
+          "Microsoft.Management/managementGroups/settings/delete",
           "Microsoft.Management/managementGroups/write",
           "Microsoft.Management/managementGroups/subscriptions/read",
           "Microsoft.Authorization/policyDefinitions/write",
@@ -494,6 +501,7 @@ variable "custom_role_definitions_bicep" {
         actions = [
           "Microsoft.Management/managementGroups/read",
           "Microsoft.Management/managementGroups/subscriptions/read",
+          "Microsoft.Management/managementGroups/settings/read",
           "Microsoft.Authorization/*/read",
           "Microsoft.Authorization/policyDefinitions/write",
           "Microsoft.Authorization/policySetDefinitions/write",

--- a/alz/local/variables.tf
+++ b/alz/local/variables.tf
@@ -208,6 +208,9 @@ variable "custom_role_definitions_terraform" {
           "Microsoft.Management/managementGroups/subscriptions/write",
           "Microsoft.Management/managementGroups/write",
           "Microsoft.Management/managementGroups/subscriptions/read",
+          "Microsoft.Management/managementGroups/settings/read",
+          "Microsoft.Management/managementGroups/settings/write",
+          "Microsoft.Management/managementGroups/settings/delete",
           "Microsoft.Authorization/*/read",
           "Microsoft.Resources/deployments/write",
           "Microsoft.Resources/deployments/exportTemplate/action"
@@ -222,6 +225,7 @@ variable "custom_role_definitions_terraform" {
         actions = [
           "Microsoft.Management/managementGroups/read",
           "Microsoft.Management/managementGroups/subscriptions/read",
+          "Microsoft.Management/managementGroups/settings/read",
           "Microsoft.Authorization/*/read",
           "Microsoft.Resources/deployments/write",
           "Microsoft.Resources/deployments/exportTemplate/action"
@@ -278,6 +282,9 @@ variable "custom_role_definitions_bicep" {
           "Microsoft.Management/managementGroups/subscriptions/write",
           "Microsoft.Management/managementGroups/write",
           "Microsoft.Management/managementGroups/subscriptions/read",
+          "Microsoft.Management/managementGroups/settings/read",
+          "Microsoft.Management/managementGroups/settings/write",
+          "Microsoft.Management/managementGroups/settings/delete",
           "Microsoft.Authorization/policyDefinitions/write",
           "Microsoft.Authorization/policySetDefinitions/write",
           "Microsoft.Authorization/policyAssignments/write",
@@ -302,6 +309,7 @@ variable "custom_role_definitions_bicep" {
         actions = [
           "Microsoft.Management/managementGroups/read",
           "Microsoft.Management/managementGroups/subscriptions/read",
+          "Microsoft.Management/managementGroups/settings/read",
           "Microsoft.Authorization/*/read",
           "Microsoft.Authorization/policyDefinitions/write",
           "Microsoft.Authorization/policySetDefinitions/write",


### PR DESCRIPTION
…settings

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

On a new Landing Zone deployment and noticed that the automation consistently got hung up on creating management group hierarchy settings until it timed out. I could not see anything happening on the activity log of the tenant root management group. I suspected the issue may be RBAC related so we updated the **Azure Landing Zones Management Group Contributor** role definition to include the "Microsoft.Management/managementGroups/settings/read" and "Microsoft.Management/managementGroups/settings/write" permissions and the deployment immediately created the settings and continued as expected. Likewise, for the **Azure Landing Zone Management Group Reader** I added the read permissions to the Azure Landing Zones Management Group Reader role.

## This PR fixes/adds/changes/removes

1. Update the Azure Landing Zone Management Group Contributor role to include the "Microsoft.Management/managementGroups/settings/read", "Microsoft.Management/managementGroups/settings/write", and "Microsoft.Management/managementGroups/settings/delete" permissions.
2. Update the Azure Landing Zone Management Group Reader role to include the "Microsoft.Management/managementGroups/settings/read" permission.

## Testing Evidence

**Stalled Azure Pipeline run:**

![image](https://github.com/user-attachments/assets/710ee4b4-0f17-4051-8f05-dc599c84c41b)

**Initital RBAC in Azure:**

![image](https://github.com/user-attachments/assets/3bc81e56-4b3b-47a0-a21d-5faf6bf35cc7)

**Updated RBAC in Azure to fix the stalled pipeline:**

![image](https://github.com/user-attachments/assets/be933894-28f9-432e-8eb5-2f05344f94d2)

<img width="994" alt="image" src="https://github.com/user-attachments/assets/41621e00-5e99-47ed-bba7-5795a7ba4ac8" />

I did not run a destroy since this was in a live environment but following sound logic I believe the delete permission would be required to run a destroy operation.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
