### PR TITLE
feat: extend custom role definitions with additional permissions for terraform

### DIFF
--- a/alz/azuredevops/variables.tf
+++ b/alz/azuredevops/variables.tf
@@ -380,9 +380,19 @@ variable "custom_role_definitions_terraform" {
           "Microsoft.Management/managementGroups/settings/read",
           "Microsoft.Management/managementGroups/settings/write",
           "Microsoft.Management/managementGroups/settings/delete",
+          "Microsoft.Authorization/policyDefinitions/write",
+          "Microsoft.Authorization/policySetDefinitions/write",
+          "Microsoft.Authorization/policyAssignments/write",
+          "Microsoft.Authorization/roleDefinitions/write",
           "Microsoft.Authorization/*/read",
+          "Microsoft.Resources/deployments/whatIf/action",
           "Microsoft.Resources/deployments/write",
-          "Microsoft.Resources/deployments/exportTemplate/action"
+          "Microsoft.Resources/deployments/validate/action",
+          "Microsoft.Resources/deployments/read",
+          "Microsoft.Resources/deployments/operationStatuses/read",
+          "Microsoft.Authorization/roleAssignments/write",
+          "Microsoft.Authorization/roleAssignments/delete",
+          "Microsoft.Insights/diagnosticSettings/write"
         ]
         not_actions = []
       }

--- a/alz/azuredevops/variables.tf
+++ b/alz/azuredevops/variables.tf
@@ -385,11 +385,8 @@ variable "custom_role_definitions_terraform" {
           "Microsoft.Authorization/policyAssignments/write",
           "Microsoft.Authorization/roleDefinitions/write",
           "Microsoft.Authorization/*/read",
-          "Microsoft.Resources/deployments/whatIf/action",
           "Microsoft.Resources/deployments/write",
-          "Microsoft.Resources/deployments/validate/action",
-          "Microsoft.Resources/deployments/read",
-          "Microsoft.Resources/deployments/operationStatuses/read",
+          "Microsoft.Resources/deployments/exportTemplate/action",
           "Microsoft.Authorization/roleAssignments/write",
           "Microsoft.Authorization/roleAssignments/delete",
           "Microsoft.Insights/diagnosticSettings/write"

--- a/alz/github/variables.tf
+++ b/alz/github/variables.tf
@@ -398,14 +398,21 @@ variable "custom_role_definitions_terraform" {
           "Microsoft.Management/managementGroups/read",
           "Microsoft.Management/managementGroups/subscriptions/delete",
           "Microsoft.Management/managementGroups/subscriptions/write",
+          "Microsoft.Management/managementGroups/write",
+          "Microsoft.Management/managementGroups/subscriptions/read",
           "Microsoft.Management/managementGroups/settings/read",
           "Microsoft.Management/managementGroups/settings/write",
           "Microsoft.Management/managementGroups/settings/delete",
-          "Microsoft.Management/managementGroups/write",
-          "Microsoft.Management/managementGroups/subscriptions/read",
+          "Microsoft.Authorization/policyDefinitions/write",
+          "Microsoft.Authorization/policySetDefinitions/write",
+          "Microsoft.Authorization/policyAssignments/write",
+          "Microsoft.Authorization/roleDefinitions/write",
           "Microsoft.Authorization/*/read",
           "Microsoft.Resources/deployments/write",
-          "Microsoft.Resources/deployments/exportTemplate/action"
+          "Microsoft.Resources/deployments/exportTemplate/action",
+          "Microsoft.Authorization/roleAssignments/write",
+          "Microsoft.Authorization/roleAssignments/delete",
+          "Microsoft.Insights/diagnosticSettings/write"
         ]
         not_actions = []
       }

--- a/alz/local/variables.tf
+++ b/alz/local/variables.tf
@@ -211,9 +211,16 @@ variable "custom_role_definitions_terraform" {
           "Microsoft.Management/managementGroups/settings/read",
           "Microsoft.Management/managementGroups/settings/write",
           "Microsoft.Management/managementGroups/settings/delete",
+          "Microsoft.Authorization/policyDefinitions/write",
+          "Microsoft.Authorization/policySetDefinitions/write",
+          "Microsoft.Authorization/policyAssignments/write",
+          "Microsoft.Authorization/roleDefinitions/write",
           "Microsoft.Authorization/*/read",
           "Microsoft.Resources/deployments/write",
-          "Microsoft.Resources/deployments/exportTemplate/action"
+          "Microsoft.Resources/deployments/exportTemplate/action",
+          "Microsoft.Authorization/roleAssignments/write",
+          "Microsoft.Authorization/roleAssignments/delete",
+          "Microsoft.Insights/diagnosticSettings/write"
         ]
         not_actions = []
       }


### PR DESCRIPTION
…Azure resources to correct deployment failures using terraform

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Currently the terraform alz_management_group_contributor role does not possess sufficient permissions to deploy custom roles and custom policies. This request aligns this role with the bicep contributor which does have the correct permissions as per [341](https://github.com/Azure/ALZ-PowerShell-Module/issues/341)

## This PR fixes/adds/changes/removes

Resolves issues whereby the custom role for terraform apply does not contain sufficient permissions to create the roles and policies required by the accelerator

### Breaking Changes

None

## Testing Evidence

Giving the apply MI owner rights to the root management group allows the roles and policies to be created. Modifying the custom role with the bicep permissions also allows this to function correctly.

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
