### PR TITLE
fix: acr task mi network permissions

### DIFF
--- a/modules/azure/container_registry.tf
+++ b/modules/azure/container_registry.tf
@@ -9,6 +9,17 @@ resource "azurerm_container_registry" "alz" {
   network_rule_bypass_option    = var.use_private_networking ? "AzureServices" : "None"
 }
 
+resource "azapi_update_resource" "network_rule_bypass_allowed_for_tasks" {
+  count       = var.use_self_hosted_agents && var.use_private_networking ? 1 : 0
+  type        = "Microsoft.ContainerRegistry/registries@2025-05-01-preview"
+  resource_id = azurerm_container_registry.alz[0].id
+  body = {
+    properties = {
+      networkRuleBypassAllowedForTasks = true
+    }
+  }
+}
+
 resource "azurerm_container_registry_task" "alz" {
   count                 = var.use_self_hosted_agents ? 1 : 0
   name                  = "image-build-task"
@@ -39,7 +50,10 @@ resource "azurerm_container_registry_task_schedule_run_now" "alz" {
   lifecycle {
     replace_triggered_by = [azurerm_container_registry_task.alz]
   }
-  depends_on = [azurerm_role_assignment.container_registry_push_for_task]
+  depends_on = [
+    azurerm_role_assignment.container_registry_push_for_task,
+    azapi_update_resource.network_rule_bypass_allowed_for_tasks
+  ]
 }
 
 resource "azurerm_role_assignment" "container_registry_pull_for_container_instance" {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Fixes a bug introduced by the ACR product group: https://learn.microsoft.com/en-us/azure/container-registry/manage-network-bypass-policy-for-tasks

## This PR fixes/adds/changes/removes

1. https://github.com/Azure/Azure-Landing-Zones/issues/2380

### Breaking Changes

None

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
