### PR TITLE
fix: Correct repository_name_templates when using single repo

### DIFF
--- a/alz/github/actions/terraform/templates/workflows/cd-template.yaml
+++ b/alz/github/actions/terraform/templates/workflows/cd-template.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
-          terraform_version: $${{ inputs.terraform_cli_versions }}
+          terraform_version: $${{ inputs.terraform_cli_version }}
 
       - name: Terraform Init
         run: |
@@ -118,7 +118,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
-          terraform_version: $${{ inputs.terraform_cli_versions }}
+          terraform_version: $${{ inputs.terraform_cli_version }}
 
       - name: Terraform Init
         run: |

--- a/alz/github/actions/terraform/templates/workflows/ci-template.yaml
+++ b/alz/github/actions/terraform/templates/workflows/ci-template.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
-          terraform_version: $${{ inputs.terraform_cli_versions }}
+          terraform_version: $${{ inputs.terraform_cli_version }}
 
       - name: Terraform Format Check
         run: |
@@ -77,7 +77,7 @@ jobs:
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
-          terraform_version: $${{ inputs.terraform_cli_versions }}
+          terraform_version: $${{ inputs.terraform_cli_version }}
 
       - name: Terraform Init
         run: |

--- a/alz/github/locals.files.tf
+++ b/alz/github/locals.files.tf
@@ -1,6 +1,6 @@
 locals {
-  self_hosted_runner_name = local.use_runner_group ? "group: ${local.resource_names.version_control_system_runner_group}" : "self-hosted"
-  runner_name             = var.use_self_hosted_runners ? local.self_hosted_runner_name : "ubuntu-latest"
+  self_hosted_runner_name   = local.use_runner_group ? "group: ${local.resource_names.version_control_system_runner_group}" : "self-hosted"
+  runner_name               = var.use_self_hosted_runners ? local.self_hosted_runner_name : "ubuntu-latest"
   repository_name_templates = var.use_separate_repository_for_templates ? local.resource_names.version_control_system_repository_templates : local.resource_names.version_control_system_repository
 }
 

--- a/alz/github/locals.files.tf
+++ b/alz/github/locals.files.tf
@@ -1,6 +1,7 @@
 locals {
   self_hosted_runner_name = local.use_runner_group ? "group: ${local.resource_names.version_control_system_runner_group}" : "self-hosted"
   runner_name             = var.use_self_hosted_runners ? local.self_hosted_runner_name : "ubuntu-latest"
+  repository_name_templates = var.use_separate_repository_for_templates ? local.resource_names.version_control_system_repository_templates : local.resource_names.version_control_system_repository
 }
 
 locals {
@@ -47,7 +48,7 @@ locals {
     {
       content = templatefile("${local.pipeline_files_directory_path}/${pipeline_file}", {
         organization_name                = var.github_organization_name
-        repository_name_templates        = local.resource_names.version_control_system_repository_templates
+        repository_name_templates        = local.repository_name_templates
         ci_template_path                 = "${local.target_folder_name}/${local.ci_template_file_name}"
         cd_template_path                 = "${local.target_folder_name}/${local.cd_template_file_name}"
         script_files                     = local.script_files
@@ -62,7 +63,7 @@ locals {
     {
       content = templatefile("${local.pipeline_template_files_directory_path}/${pipeline_template_file}", {
         organization_name                            = var.github_organization_name
-        repository_name_templates                    = local.resource_names.version_control_system_repository_templates
+        repository_name_templates                    = local.repository_name_templates
         runner_name                                  = local.runner_name
         environment_name_plan                        = local.resource_names.version_control_system_environment_plan
         environment_name_apply                       = local.resource_names.version_control_system_environment_apply


### PR DESCRIPTION
## Overview/Summary

Set the uses: value correctly when using single repo in combincation with Terraform and GitHub.

Replicates the logic used for azuredevops / terraform, and applies it to github / terraform.

## This PR fixes

1 [#391](https://github.com/Azure/ALZ-PowerShell-Module/issues/391)

## Testing Evidence

Tested on bootstrap in pwsh on Ubuntu 24.04, and then ran the two workflows.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
