### PR TITLE
feat: Optional Resource Names for Accelerator

### DIFF
--- a/alz/azuredevops/variables.tf
+++ b/alz/azuredevops/variables.tf
@@ -274,45 +274,45 @@ variable "module_folder_path_relative" {
 }
 
 variable "resource_names" {
-  type        = map(string)
+  type = object({
+    resource_group_state                                       = optional(string, "rg-{{service_name}}-{{environment_name}}-state-{{azure_location}}-{{postfix_number}}")
+    resource_group_identity                                    = optional(string, "rg-{{service_name}}-{{environment_name}}-identity-{{azure_location}}-{{postfix_number}}")
+    resource_group_agents                                      = optional(string, "rg-{{service_name}}-{{environment_name}}-agents-{{azure_location}}-{{postfix_number}}")
+    resource_group_network                                     = optional(string, "rg-{{service_name}}-{{environment_name}}-network-{{azure_location}}-{{postfix_number}}")
+    user_assigned_managed_identity_plan                        = optional(string, "id-{{service_name}}-{{environment_name}}-{{azure_location}}-plan-{{postfix_number}}")
+    user_assigned_managed_identity_apply                       = optional(string, "id-{{service_name}}-{{environment_name}}-{{azure_location}}-apply-{{postfix_number}}")
+    user_assigned_managed_identity_federated_credentials_plan  = optional(string, "id-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}-plan")
+    user_assigned_managed_identity_federated_credentials_apply = optional(string, "id-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}-apply")
+    storage_account                                            = optional(string, "sto{{service_name_short}}{{environment_name_short}}{{azure_location_short}}{{postfix_number}}{{random_string}}")
+    storage_container                                          = optional(string, "{{environment_name}}-tfstate")
+    container_instance_01                                      = optional(string, "aci-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}")
+    container_instance_02                                      = optional(string, "aci-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number_plus_1}}")
+    container_instance_managed_identity                        = optional(string, "id-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}-aci")
+    agent_01                                                   = optional(string, "agent-{{service_name}}-{{environment_name}}-{{postfix_number}}")
+    agent_02                                                   = optional(string, "agent-{{service_name}}-{{environment_name}}-{{postfix_number_plus_1}}")
+    version_control_system_repository                          = optional(string, "{{service_name}}-{{environment_name}}")
+    version_control_system_repository_templates                = optional(string, "{{service_name}}-{{environment_name}}-templates")
+    version_control_system_service_connection_plan             = optional(string, "sc-{{service_name}}-{{environment_name}}-plan")
+    version_control_system_service_connection_apply            = optional(string, "sc-{{service_name}}-{{environment_name}}-apply")
+    version_control_system_environment_plan                    = optional(string, "{{service_name}}-{{environment_name}}-plan")
+    version_control_system_environment_apply                   = optional(string, "{{service_name}}-{{environment_name}}-apply")
+    version_control_system_variable_group                      = optional(string, "{{service_name}}-{{environment_name}}")
+    version_control_system_agent_pool                          = optional(string, "{{service_name}}-{{environment_name}}")
+    version_control_system_group                               = optional(string, "{{service_name}}-{{environment_name}}-approvers")
+    version_control_system_pipeline_name_ci                    = optional(string, "01 Azure Landing Zones Continuous Integration")
+    version_control_system_pipeline_name_cd                    = optional(string, "02 Azure Landing Zones Continuous Delivery")
+    virtual_network                                            = optional(string, "vnet-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}")
+    public_ip                                                  = optional(string, "pip-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}")
+    nat_gateway                                                = optional(string, "nat-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}")
+    subnet_container_instances                                 = optional(string, "subnet-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}-aci")
+    subnet_private_endpoints                                   = optional(string, "subnet-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}-pe")
+    storage_account_private_endpoint                           = optional(string, "pe-{{service_name}}-{{environment_name}}-{{azure_location}}-sto-{{postfix_number}}")
+    container_registry                                         = optional(string, "acr{{service_name}}{{environment_name}}{{azure_location_short}}{{postfix_number}}{{random_string}}")
+    container_registry_private_endpoint                        = optional(string, "pe-{{service_name}}-{{environment_name}}-{{azure_location}}-acr-{{postfix_number}}")
+    container_image_name                                       = optional(string, "azure-devops-agent")
+  })
   description = "Overrides for resource names"
-  default = {
-    resource_group_state                                       = "rg-{{service_name}}-{{environment_name}}-state-{{azure_location}}-{{postfix_number}}"
-    resource_group_identity                                    = "rg-{{service_name}}-{{environment_name}}-identity-{{azure_location}}-{{postfix_number}}"
-    resource_group_agents                                      = "rg-{{service_name}}-{{environment_name}}-agents-{{azure_location}}-{{postfix_number}}"
-    resource_group_network                                     = "rg-{{service_name}}-{{environment_name}}-network-{{azure_location}}-{{postfix_number}}"
-    user_assigned_managed_identity_plan                        = "id-{{service_name}}-{{environment_name}}-{{azure_location}}-plan-{{postfix_number}}"
-    user_assigned_managed_identity_apply                       = "id-{{service_name}}-{{environment_name}}-{{azure_location}}-apply-{{postfix_number}}"
-    user_assigned_managed_identity_federated_credentials_plan  = "id-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}-plan"
-    user_assigned_managed_identity_federated_credentials_apply = "id-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}-apply"
-    storage_account                                            = "sto{{service_name_short}}{{environment_name_short}}{{azure_location_short}}{{postfix_number}}{{random_string}}"
-    storage_container                                          = "{{environment_name}}-tfstate"
-    container_instance_01                                      = "aci-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}"
-    container_instance_02                                      = "aci-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number_plus_1}}"
-    container_instance_managed_identity                        = "id-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}-aci"
-    agent_01                                                   = "agent-{{service_name}}-{{environment_name}}-{{postfix_number}}"
-    agent_02                                                   = "agent-{{service_name}}-{{environment_name}}-{{postfix_number_plus_1}}"
-    version_control_system_repository                          = "{{service_name}}-{{environment_name}}"
-    version_control_system_repository_templates                = "{{service_name}}-{{environment_name}}-templates"
-    version_control_system_service_connection_plan             = "sc-{{service_name}}-{{environment_name}}-plan"
-    version_control_system_service_connection_apply            = "sc-{{service_name}}-{{environment_name}}-apply"
-    version_control_system_environment_plan                    = "{{service_name}}-{{environment_name}}-plan"
-    version_control_system_environment_apply                   = "{{service_name}}-{{environment_name}}-apply"
-    version_control_system_variable_group                      = "{{service_name}}-{{environment_name}}"
-    version_control_system_agent_pool                          = "{{service_name}}-{{environment_name}}"
-    version_control_system_group                               = "{{service_name}}-{{environment_name}}-approvers"
-    version_control_system_pipeline_name_ci                    = "01 Azure Landing Zones Continuous Integration"
-    version_control_system_pipeline_name_cd                    = "02 Azure Landing Zones Continuous Delivery"
-    virtual_network                                            = "vnet-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}"
-    public_ip                                                  = "pip-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}"
-    nat_gateway                                                = "nat-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}"
-    subnet_container_instances                                 = "subnet-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}-aci"
-    subnet_private_endpoints                                   = "subnet-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}-pe"
-    storage_account_private_endpoint                           = "pe-{{service_name}}-{{environment_name}}-{{azure_location}}-sto-{{postfix_number}}"
-    container_registry                                         = "acr{{service_name}}{{environment_name}}{{azure_location_short}}{{postfix_number}}{{random_string}}"
-    container_registry_private_endpoint                        = "pe-{{service_name}}-{{environment_name}}-{{azure_location}}-acr-{{postfix_number}}"
-    container_image_name                                       = "azure-devops-agent"
-  }
+  default     = {}
 }
 
 variable "agent_name_environment_variable" {

--- a/alz/github/variables.tf
+++ b/alz/github/variables.tf
@@ -243,39 +243,39 @@ variable "module_folder_path_relative" {
 }
 
 variable "resource_names" {
-  type        = map(string)
+  type = object({
+    resource_group_state                                        = optional(string, "rg-{{service_name}}-{{environment_name}}-state-{{azure_location}}-{{postfix_number}}")
+    resource_group_identity                                     = optional(string, "rg-{{service_name}}-{{environment_name}}-identity-{{azure_location}}-{{postfix_number}}")
+    resource_group_agents                                       = optional(string, "rg-{{service_name}}-{{environment_name}}-agents-{{azure_location}}-{{postfix_number}}")
+    resource_group_network                                      = optional(string, "rg-{{service_name}}-{{environment_name}}-network-{{azure_location}}-{{postfix_number}}")
+    user_assigned_managed_identity_plan                         = optional(string, "id-{{service_name}}-{{environment_name}}-{{azure_location}}-plan-{{postfix_number}}")
+    user_assigned_managed_identity_apply                        = optional(string, "id-{{service_name}}-{{environment_name}}-{{azure_location}}-apply-{{postfix_number}}")
+    user_assigned_managed_identity_federated_credentials_prefix = optional(string, "{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}")
+    storage_account                                             = optional(string, "sto{{service_name_short}}{{environment_name_short}}{{azure_location_short}}{{postfix_number}}{{random_string}}")
+    storage_container                                           = optional(string, "{{environment_name}}-tfstate")
+    container_instance_01                                       = optional(string, "aci-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}")
+    container_instance_02                                       = optional(string, "aci-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number_plus_1}}")
+    container_instance_managed_identity                         = optional(string, "id-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}-aci")
+    runner_01                                                   = optional(string, "runner-{{service_name}}-{{environment_name}}-{{postfix_number}}")
+    runner_02                                                   = optional(string, "runner-{{service_name}}-{{environment_name}}-{{postfix_number_plus_1}}")
+    version_control_system_repository                           = optional(string, "{{service_name}}-{{environment_name}}")
+    version_control_system_repository_templates                 = optional(string, "{{service_name}}-{{environment_name}}-templates")
+    version_control_system_environment_plan                     = optional(string, "{{service_name}}-{{environment_name}}-plan")
+    version_control_system_environment_apply                    = optional(string, "{{service_name}}-{{environment_name}}-apply")
+    version_control_system_team                                 = optional(string, "{{service_name}}-{{environment_name}}-approvers")
+    version_control_system_runner_group                         = optional(string, "{{service_name}}-{{environment_name}}")
+    virtual_network                                             = optional(string, "vnet-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}")
+    public_ip                                                   = optional(string, "pip-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}")
+    nat_gateway                                                 = optional(string, "nat-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}")
+    subnet_container_instances                                  = optional(string, "subnet-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}-aci")
+    subnet_private_endpoints                                    = optional(string, "subnet-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}-pe")
+    storage_account_private_endpoint                            = optional(string, "pe-{{service_name}}-{{environment_name}}-{{azure_location}}-sto-{{postfix_number}}")
+    container_registry                                          = optional(string, "acr{{service_name}}{{environment_name}}{{azure_location_short}}{{postfix_number}}{{random_string}}")
+    container_registry_private_endpoint                         = optional(string, "pe-{{service_name}}-{{environment_name}}-{{azure_location}}-acr-{{postfix_number}}")
+    container_image_name                                        = optional(string, "github-runner")
+  })
   description = "Overrides for resource names"
-  default = {
-    resource_group_state                                        = "rg-{{service_name}}-{{environment_name}}-state-{{azure_location}}-{{postfix_number}}"
-    resource_group_identity                                     = "rg-{{service_name}}-{{environment_name}}-identity-{{azure_location}}-{{postfix_number}}"
-    resource_group_agents                                       = "rg-{{service_name}}-{{environment_name}}-agents-{{azure_location}}-{{postfix_number}}"
-    resource_group_network                                      = "rg-{{service_name}}-{{environment_name}}-network-{{azure_location}}-{{postfix_number}}"
-    user_assigned_managed_identity_plan                         = "id-{{service_name}}-{{environment_name}}-{{azure_location}}-plan-{{postfix_number}}"
-    user_assigned_managed_identity_apply                        = "id-{{service_name}}-{{environment_name}}-{{azure_location}}-apply-{{postfix_number}}"
-    user_assigned_managed_identity_federated_credentials_prefix = "{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}"
-    storage_account                                             = "sto{{service_name_short}}{{environment_name_short}}{{azure_location_short}}{{postfix_number}}{{random_string}}"
-    storage_container                                           = "{{environment_name}}-tfstate"
-    container_instance_01                                       = "aci-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}"
-    container_instance_02                                       = "aci-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number_plus_1}}"
-    container_instance_managed_identity                         = "id-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}-aci"
-    runner_01                                                   = "runner-{{service_name}}-{{environment_name}}-{{postfix_number}}"
-    runner_02                                                   = "runner-{{service_name}}-{{environment_name}}-{{postfix_number_plus_1}}"
-    version_control_system_repository                           = "{{service_name}}-{{environment_name}}"
-    version_control_system_repository_templates                 = "{{service_name}}-{{environment_name}}-templates"
-    version_control_system_environment_plan                     = "{{service_name}}-{{environment_name}}-plan"
-    version_control_system_environment_apply                    = "{{service_name}}-{{environment_name}}-apply"
-    version_control_system_team                                 = "{{service_name}}-{{environment_name}}-approvers"
-    version_control_system_runner_group                         = "{{service_name}}-{{environment_name}}"
-    virtual_network                                             = "vnet-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}"
-    public_ip                                                   = "pip-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}"
-    nat_gateway                                                 = "nat-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}"
-    subnet_container_instances                                  = "subnet-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}-aci"
-    subnet_private_endpoints                                    = "subnet-{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}-pe"
-    storage_account_private_endpoint                            = "pe-{{service_name}}-{{environment_name}}-{{azure_location}}-sto-{{postfix_number}}"
-    container_registry                                          = "acr{{service_name}}{{environment_name}}{{azure_location_short}}{{postfix_number}}{{random_string}}"
-    container_registry_private_endpoint                         = "pe-{{service_name}}-{{environment_name}}-{{azure_location}}-acr-{{postfix_number}}"
-    container_image_name                                        = "github-runner"
-  }
+  default     = {}
 }
 
 variable "runner_container_image_repository" {

--- a/alz/local/variables.tf
+++ b/alz/local/variables.tf
@@ -168,17 +168,17 @@ variable "module_folder_path_relative" {
 }
 
 variable "resource_names" {
-  type        = map(string)
+  type = object({
+    resource_group_state                                        = optional(string, "rg-{{service_name}}-{{environment_name}}-state-{{azure_location}}-{{postfix_number}}")
+    resource_group_identity                                     = optional(string, "rg-{{service_name}}-{{environment_name}}-identity-{{azure_location}}-{{postfix_number}}")
+    user_assigned_managed_identity_plan                         = optional(string, "id-{{service_name}}-{{environment_name}}-{{azure_location}}-plan-{{postfix_number}}")
+    user_assigned_managed_identity_apply                        = optional(string, "id-{{service_name}}-{{environment_name}}-{{azure_location}}-apply-{{postfix_number}}")
+    user_assigned_managed_identity_federated_credentials_prefix = optional(string, "{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}")
+    storage_account                                             = optional(string, "sto{{service_name_short}}{{environment_name_short}}{{azure_location_short}}{{postfix_number}}{{random_string}}")
+    storage_container                                           = optional(string, "{{environment_name}}-tfstate")
+  })
   description = "Overrides for resource names"
-  default = {
-    resource_group_state                                        = "rg-{{service_name}}-{{environment_name}}-state-{{azure_location}}-{{postfix_number}}"
-    resource_group_identity                                     = "rg-{{service_name}}-{{environment_name}}-identity-{{azure_location}}-{{postfix_number}}"
-    user_assigned_managed_identity_plan                         = "id-{{service_name}}-{{environment_name}}-{{azure_location}}-plan-{{postfix_number}}"
-    user_assigned_managed_identity_apply                        = "id-{{service_name}}-{{environment_name}}-{{azure_location}}-apply-{{postfix_number}}"
-    user_assigned_managed_identity_federated_credentials_prefix = "{{service_name}}-{{environment_name}}-{{azure_location}}-{{postfix_number}}"
-    storage_account                                             = "sto{{service_name_short}}{{environment_name_short}}{{azure_location_short}}{{postfix_number}}{{random_string}}"
-    storage_container                                           = "{{environment_name}}-tfstate"
-  }
+  default     = {}
 }
 
 variable "federated_credentials" {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Changed the resource name variables for each accelerator option (ADO, GitHub & Local) to an object with optionals rather than a map. This stops the user having to override all names and can select the one in scope.

## This PR fixes/adds/changes/removes

1. [https://github.com/Azure/ALZ-PowerShell-Module/issues/441](#441)

### Breaking Changes

N/A

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
