### PR TITLE
fix: pin vcs provider versions

### DIFF
--- a/modules/azure_devops/terraform.tf
+++ b/modules/azure_devops/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "~> 1.7"
+      version = "1.11.2"
     }
   }
 }

--- a/modules/github/terraform.tf
+++ b/modules/github/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "~> 6.5"
+      version = "6.8.1"
     }
   }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Pin VCS provider versions. There is a bug in 6.8.2 of the GitHub provider: https://github.com/integrations/terraform-provider-github/issues/2903

## This PR fixes/adds/changes/removes

N/A

### Breaking Changes

None

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
