### PR TITLE
fix: remove 'Show env' step from end-to-end test workflow

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -79,9 +79,6 @@ jobs:
 
     runs-on: ${{ matrix.operatingSystem }}-latest
     steps:
-      - name: Show env
-        run: env | sort
-
       - name: Checkout Bootstrap Modules
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
Avoid risk of exfil