### PR TITLE
fix: align subscription_ids variable across azuredevops, github, and local

### DIFF
--- a/alz/azuredevops/locals.tf
+++ b/alz/azuredevops/locals.tf
@@ -34,7 +34,7 @@ locals {
 }
 
 locals {
-  target_subscriptions = distinct(values(var.subscription_ids))
+  target_subscriptions = distinct([for v in values(var.subscription_ids) : v if v != null && v != ""])
 }
 
 locals {

--- a/alz/azuredevops/variables.tf
+++ b/alz/azuredevops/variables.tf
@@ -26,12 +26,28 @@ variable "root_parent_management_group_id" {
   default     = ""
 }
 
+variable "required_subscription_keys" {
+  description = <<-EOT
+    **(Optional, default: `["management", "connectivity"]`)** List of subscription keys that must be present with valid GUID values.
+
+    Keys not in this list may have null or empty string values.
+    Valid keys: 'management', 'connectivity', 'identity', 'security'
+  EOT
+  type        = list(string)
+  default     = ["management", "connectivity"]
+  nullable    = false
+  validation {
+    condition     = alltrue([for key in var.required_subscription_keys : contains(["management", "connectivity", "identity", "security"], key)])
+    error_message = "The required_subscription_keys must be one of 'management', 'connectivity', 'identity' or 'security'"
+  }
+}
+
 variable "subscription_ids" {
   description = <<-EOT
     **(Optional, default: `{}`)** Map of Azure subscription IDs where Platform Landing Zone resources will be deployed.
 
     Keys must be one of: 'management', 'connectivity', 'identity', 'security'
-    Values must be valid Azure subscription GUIDs.
+    Values must be valid Azure subscription GUIDs, or null/empty for non-required keys.
 
     Example:
     ```
@@ -45,16 +61,16 @@ variable "subscription_ids" {
   default     = {}
   nullable    = false
   validation {
-    condition     = alltrue([for id in values(var.subscription_ids) : can(regex("^[0-9a-fA-F-]{36}$", id))])
-    error_message = "All subscription IDs must be valid GUIDs"
+    condition     = alltrue([for key, id in var.subscription_ids : contains(var.required_subscription_keys, key) ? can(regex("^[0-9a-fA-F-]{36}$", id)) : (id == null || id == "" || can(regex("^[0-9a-fA-F-]{36}$", id)))])
+    error_message = "Required subscription IDs must be valid GUIDs. Optional subscription IDs must be valid GUIDs, null, or empty string."
   }
   validation {
-    condition     = alltrue([for id in keys(var.subscription_ids) : contains(["management", "connectivity", "identity", "security"], id)])
+    condition     = alltrue([for key in keys(var.subscription_ids) : contains(["management", "connectivity", "identity", "security"], key)])
     error_message = "The keys of the subscription_ids map must be one of 'management', 'connectivity', 'identity' or 'security'"
   }
   validation {
-    condition     = contains(keys(var.subscription_ids), "management") && contains(keys(var.subscription_ids), "connectivity")
-    error_message = "You must provide subscription IDs for: 'management', and 'connectivity'"
+    condition     = alltrue([for key in var.required_subscription_keys : contains(keys(var.subscription_ids), key)])
+    error_message = "You must provide subscription IDs for all required subscription keys."
   }
 }
 

--- a/alz/azuredevops/variables.tf
+++ b/alz/azuredevops/variables.tf
@@ -45,7 +45,7 @@ variable "subscription_ids" {
   default     = {}
   nullable    = false
   validation {
-    condition     = alltrue([for id in values(var.subscription_ids) : can(regex("^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$", id))])
+    condition     = alltrue([for id in values(var.subscription_ids) : can(regex("^[0-9a-fA-F-]{36}$", id))])
     error_message = "All subscription IDs must be valid GUIDs"
   }
   validation {
@@ -53,8 +53,8 @@ variable "subscription_ids" {
     error_message = "The keys of the subscription_ids map must be one of 'management', 'connectivity', 'identity' or 'security'"
   }
   validation {
-    condition     = contains(keys(var.subscription_ids), "management") && contains(keys(var.subscription_ids), "connectivity") && contains(keys(var.subscription_ids), "identity")
-    error_message = "You must provide subscription IDs for: 'management', 'connectivity', and 'identity'"
+    condition     = contains(keys(var.subscription_ids), "management") && contains(keys(var.subscription_ids), "connectivity")
+    error_message = "You must provide subscription IDs for: 'management', and 'connectivity'"
   }
 }
 

--- a/alz/github/locals.tf
+++ b/alz/github/locals.tf
@@ -41,7 +41,7 @@ locals {
 }
 
 locals {
-  target_subscriptions = distinct(values(var.subscription_ids))
+  target_subscriptions = distinct([for v in values(var.subscription_ids) : v if v != null && v != ""])
 }
 
 locals {

--- a/alz/github/variables.tf
+++ b/alz/github/variables.tf
@@ -26,12 +26,28 @@ variable "root_parent_management_group_id" {
   default     = ""
 }
 
+variable "required_subscription_keys" {
+  description = <<-EOT
+    **(Optional, default: `["management", "connectivity"]`)** List of subscription keys that must be present with valid GUID values.
+
+    Keys not in this list may have null or empty string values.
+    Valid keys: 'management', 'connectivity', 'identity', 'security'
+  EOT
+  type        = list(string)
+  default     = ["management", "connectivity"]
+  nullable    = false
+  validation {
+    condition     = alltrue([for key in var.required_subscription_keys : contains(["management", "connectivity", "identity", "security"], key)])
+    error_message = "The required_subscription_keys must be one of 'management', 'connectivity', 'identity' or 'security'"
+  }
+}
+
 variable "subscription_ids" {
   description = <<-EOT
     **(Optional, default: `{}`)** Map of Azure subscription IDs where Platform Landing Zone resources will be deployed.
 
     Keys must be one of: 'management', 'connectivity', 'identity', 'security'
-    Values must be valid Azure subscription GUIDs.
+    Values must be valid Azure subscription GUIDs, or null/empty for non-required keys.
 
     Example:
     ```
@@ -45,16 +61,16 @@ variable "subscription_ids" {
   default     = {}
   nullable    = false
   validation {
-    condition     = alltrue([for id in values(var.subscription_ids) : can(regex("^[0-9a-fA-F-]{36}$", id))])
-    error_message = "All subscription IDs must be valid GUIDs"
+    condition     = alltrue([for key, id in var.subscription_ids : contains(var.required_subscription_keys, key) ? can(regex("^[0-9a-fA-F-]{36}$", id)) : (id == null || id == "" || can(regex("^[0-9a-fA-F-]{36}$", id)))])
+    error_message = "Required subscription IDs must be valid GUIDs. Optional subscription IDs must be valid GUIDs, null, or empty string."
   }
   validation {
-    condition     = alltrue([for id in keys(var.subscription_ids) : contains(["management", "connectivity", "identity", "security"], id)])
+    condition     = alltrue([for key in keys(var.subscription_ids) : contains(["management", "connectivity", "identity", "security"], key)])
     error_message = "The keys of the subscription_ids map must be one of 'management', 'connectivity', 'identity' or 'security'"
   }
   validation {
-    condition     = contains(keys(var.subscription_ids), "management") && contains(keys(var.subscription_ids), "connectivity")
-    error_message = "You must provide subscription IDs for: 'management', and 'connectivity'"
+    condition     = alltrue([for key in var.required_subscription_keys : contains(keys(var.subscription_ids), key)])
+    error_message = "You must provide subscription IDs for all required subscription keys."
   }
 }
 

--- a/alz/github/variables.tf
+++ b/alz/github/variables.tf
@@ -53,8 +53,8 @@ variable "subscription_ids" {
     error_message = "The keys of the subscription_ids map must be one of 'management', 'connectivity', 'identity' or 'security'"
   }
   validation {
-    condition     = contains(keys(var.subscription_ids), "management") && contains(keys(var.subscription_ids), "connectivity") && contains(keys(var.subscription_ids), "identity")
-    error_message = "You must provide subscription IDs for: 'management', 'connectivity', and 'identity'"
+    condition     = contains(keys(var.subscription_ids), "management") && contains(keys(var.subscription_ids), "connectivity")
+    error_message = "You must provide subscription IDs for: 'management', and 'connectivity'"
   }
 }
 

--- a/alz/local/locals.tf
+++ b/alz/local/locals.tf
@@ -17,7 +17,7 @@ locals {
 }
 
 locals {
-  target_subscriptions = distinct(values(var.subscription_ids))
+  target_subscriptions = distinct([for v in values(var.subscription_ids) : v if v != null && v != ""])
 }
 
 locals {

--- a/alz/local/variables.tf
+++ b/alz/local/variables.tf
@@ -26,12 +26,28 @@ variable "root_parent_management_group_id" {
   default     = ""
 }
 
+variable "required_subscription_keys" {
+  description = <<-EOT
+    **(Optional, default: `["management", "connectivity"]`)** List of subscription keys that must be present with valid GUID values.
+
+    Keys not in this list may have null or empty string values.
+    Valid keys: 'management', 'connectivity', 'identity', 'security'
+  EOT
+  type        = list(string)
+  default     = ["management", "connectivity"]
+  nullable    = false
+  validation {
+    condition     = alltrue([for key in var.required_subscription_keys : contains(["management", "connectivity", "identity", "security"], key)])
+    error_message = "The required_subscription_keys must be one of 'management', 'connectivity', 'identity' or 'security'"
+  }
+}
+
 variable "subscription_ids" {
   description = <<-EOT
     **(Optional, default: `{}`)** Map of Azure subscription IDs where Platform Landing Zone resources will be deployed.
 
     Keys must be one of: 'management', 'connectivity', 'identity', 'security'
-    Values must be valid Azure subscription GUIDs.
+    Values must be valid Azure subscription GUIDs, or null/empty for non-required keys.
 
     Example:
     ```
@@ -45,16 +61,16 @@ variable "subscription_ids" {
   default     = {}
   nullable    = false
   validation {
-    condition     = alltrue([for id in values(var.subscription_ids) : can(regex("^[0-9a-fA-F-]{36}$", id))])
-    error_message = "All subscription IDs must be valid GUIDs"
+    condition     = alltrue([for key, id in var.subscription_ids : contains(var.required_subscription_keys, key) ? can(regex("^[0-9a-fA-F-]{36}$", id)) : (id == null || id == "" || can(regex("^[0-9a-fA-F-]{36}$", id)))])
+    error_message = "Required subscription IDs must be valid GUIDs. Optional subscription IDs must be valid GUIDs, null, or empty string."
   }
   validation {
-    condition     = alltrue([for id in keys(var.subscription_ids) : contains(["management", "connectivity", "identity", "security"], id)])
+    condition     = alltrue([for key in keys(var.subscription_ids) : contains(["management", "connectivity", "identity", "security"], key)])
     error_message = "The keys of the subscription_ids map must be one of 'management', 'connectivity', 'identity' or 'security'"
   }
   validation {
-    condition     = contains(keys(var.subscription_ids), "management") && contains(keys(var.subscription_ids), "connectivity")
-    error_message = "You must provide subscription IDs for: 'management', and 'connectivity'"
+    condition     = alltrue([for key in var.required_subscription_keys : contains(keys(var.subscription_ids), key)])
+    error_message = "You must provide subscription IDs for all required subscription keys."
   }
 }
 

--- a/alz/local/variables.tf
+++ b/alz/local/variables.tf
@@ -28,7 +28,7 @@ variable "root_parent_management_group_id" {
 
 variable "subscription_ids" {
   description = <<-EOT
-    **(Optional, default: `{}`)**  Map of Azure subscription IDs where Platform Landing Zone resources will be deployed.
+    **(Optional, default: `{}`)** Map of Azure subscription IDs where Platform Landing Zone resources will be deployed.
 
     Keys must be one of: 'management', 'connectivity', 'identity', 'security'
     Values must be valid Azure subscription GUIDs.
@@ -53,8 +53,8 @@ variable "subscription_ids" {
     error_message = "The keys of the subscription_ids map must be one of 'management', 'connectivity', 'identity' or 'security'"
   }
   validation {
-    condition     = contains(keys(var.subscription_ids), "management") && contains(keys(var.subscription_ids), "connectivity") && contains(keys(var.subscription_ids), "identity")
-    error_message = "You must provide subscription IDs for: 'management', 'connectivity', and 'identity'"
+    condition     = contains(keys(var.subscription_ids), "management") && contains(keys(var.subscription_ids), "connectivity")
+    error_message = "You must provide subscription IDs for: 'management', and 'connectivity'"
   }
 }
 

--- a/modules/azure/data.tf
+++ b/modules/azure/data.tf
@@ -1,5 +1,3 @@
-data "azurerm_client_config" "alz" {}
-
 data "azurerm_subscription" "alz" {
   for_each        = local.subscription_ids
   subscription_id = each.key


### PR DESCRIPTION
## Summary

https://github.com/Azure/Azure-Landing-Zones/issues/4095

Align the subscription_ids variable definition in lz/azuredevops/variables.tf and lz/local/variables.tf to match lz/github/variables.tf.

## Changes
- **azuredevops**: Simplify GUID regex from verbose pattern to ^[0-9a-fA-F-]{36}$`n- **azuredevops, github, local**: Remove identity from required subscription keys — only management and connectivity are now required
- **local**: Fix extra space in description text
