### PR TITLE
fix(github): use API-resolved org login for OIDC subject claims

### DIFF
--- a/modules/github/locals.tf
+++ b/modules/github/locals.tf
@@ -18,14 +18,14 @@ locals {
 
 locals {
   repository_name_templates = var.use_template_repository ? var.repository_name_templates : var.repository_name
-  template_claim_structure  = "${var.organization_name}/${local.repository_name_templates}/%s@refs/heads/main"
+  template_claim_structure  = "${lower(data.github_organization.alz.login)}/${local.repository_name_templates}/%s@refs/heads/main"
 
   oidc_subjects_flattened = flatten([for key, value in var.workflows : [
     for environment_user_assigned_managed_identity_mapping in value.environment_user_assigned_managed_identity_mappings :
     {
       subject_key                        = "${key}-${environment_user_assigned_managed_identity_mapping.user_assigned_managed_identity_key}"
       user_assigned_managed_identity_key = environment_user_assigned_managed_identity_mapping.user_assigned_managed_identity_key
-      subject                            = "repo:${var.organization_name}/${var.repository_name}:environment:${var.environments[environment_user_assigned_managed_identity_mapping.environment_key]}:job_workflow_ref:${format(local.template_claim_structure, value.workflow_file_name)}"
+      subject                            = "repo:${data.github_organization.alz.login}/${var.repository_name}:environment:${var.environments[environment_user_assigned_managed_identity_mapping.environment_key]}:job_workflow_ref:${format(local.template_claim_structure, value.workflow_file_name)}"
     }
     ]
   ])


### PR DESCRIPTION
## TL;DR
Hi Team!! I found this issue while using Deploy-Accelerator and wanted to submit the fix I found. This PR fixes GitHub OIDC federated credential subject casing mismatches that can cause `AADSTS7002138` after Entra case-sensitive matching enforcement.

The module previously built subject claims from raw user input (`var.organization_name`), which can differ from GitHub’s canonical org login casing.  
This change uses `data.github_organization.alz.login` for the `repo:` segment and uses `lower(data.github_organization.alz.login)` for the `job_workflow_ref` org segment.

Result: future bootstrap deployments generate subject claims that match runtime GitHub token assertions for the org casing scenario you hit.

---

## Detailed Notes

### Problem
Entra (Azure AD) now enforces case-sensitive matching on federated credential subjects.  
The bootstrap GitHub module generated subject claims using user-entered org name casing, which can differ from GitHub’s canonical org login casing used in OIDC assertions.

Observed failure:
`AADSTS7002138: No matching federated identity record found for presented assertion subject`

### Impact
If org casing in inputs differs from GitHub canonical login casing, GitHub Actions authentication to Azure can fail for plan/apply workflows that rely on workload identity federation.

### Root Cause
Subject claims were composed from:
- `var.organization_name` (raw user input)

instead of:
- `data.github_organization.alz.login` (provider/API-resolved canonical org login)

### What Changed
File changed:
- locals.tf

Code updates:
1. `template_claim_structure` now uses:
   `lower(data.github_organization.alz.login)`  
2. `subject` (`repo:` segment) now uses:
   `data.github_organization.alz.login`

### Why This Fix
- Removes dependency on user-typed casing.
- Uses GitHub provider data as source of truth.
- Minimal, targeted change in the only GitHub OIDC subject generation path.

### Validation Performed
1. Confirmed only one active GitHub subject construction path exists.
2. Confirmed flow from github outputs into Azure federated credential resource.
3. Confirmed diff scope is only two substitutions in one file.
4. Branch and commit are isolated to this bug fix.

### Risk / Compatibility
- Low risk: no new resources, no schema changes, only subject string composition source.
- Backward compatible for already-correct inputs.
- Fixes incorrect/mixed-case input scenarios.

### Operational Note for Existing Deployments
This PR prevents future incorrect subject generation.  
Already-deployed credentials with wrong subject values may still require delete + recreate to ensure Entra-side propagation, as documented in incident notes.

### Reference
- Error: `AADSTS7002138`  
- Microsoft breaking change (Aug 2024): Federated Identity Credentials now use case-sensitive matching (issuer, subject, audience). 
- https://learn.microsoft.com/en-us/entra/identity-platform/reference-breaking-changes#august-2024