### PR TITLE
fix: pin terraform CLI version to 1.14.9 in ci/cd pipelines

### DIFF
--- a/alz/azuredevops/pipelines/terraform/main/cd.yaml
+++ b/alz/azuredevops/pipelines/terraform/main/cd.yaml
@@ -21,7 +21,7 @@ parameters:
   - name: terraform_cli_version
     displayName: Terraform CLI Version
     type: string
-    default: 'latest'
+    default: '1.14.9'
 
 lockBehavior: sequential
 

--- a/alz/azuredevops/pipelines/terraform/main/ci.yaml
+++ b/alz/azuredevops/pipelines/terraform/main/ci.yaml
@@ -12,7 +12,7 @@ parameters:
   - name: terraform_cli_version
     displayName: Terraform CLI Version
     type: string
-    default: 'latest'
+    default: '1.14.9'
 
 lockBehavior: sequential
 

--- a/alz/github/actions/terraform/main/workflows/cd.yaml
+++ b/alz/github/actions/terraform/main/workflows/cd.yaml
@@ -17,7 +17,7 @@ on:
       terraform_cli_version:
         description: 'Terraform CLI Version'
         required: true
-        default: 'latest'
+        default: '1.14.9'
         type: string
 
 jobs:

--- a/alz/github/actions/terraform/main/workflows/ci.yaml
+++ b/alz/github/actions/terraform/main/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
       terraform_cli_version:
         description: 'Terraform CLI Version'
         required: true
-        default: 'latest'
+        default: '1.14.9'
         type: string
 
 jobs:


### PR DESCRIPTION
## Summary

Replaces the 'latest' default with pinned version 1.14.9 for the 	erraform_cli_version parameter across:

- `alz/azuredevops/pipelines/terraform/main/ci.yaml`
- `alz/azuredevops/pipelines/terraform/main/cd.yaml`
- `alz/github/actions/terraform/main/workflows/ci.yaml`
- `alz/github/actions/terraform/main/workflows/cd.yaml`

## Why

The 1.15.0 release has a bug: https://github.com/hashicorp/terraform/issues/38463