### PR TITLE
fix: Render empty subscription arrays correctly (#4195)

### DIFF
--- a/modules/file_manipulation/locals.bicep.tf
+++ b/modules/file_manipulation/locals.bicep.tf
@@ -27,7 +27,7 @@ locals {
 
   bicep_module_files_templated = { for key, value in local.bicep_module_files_prepped_for_templating : key =>
     {
-      content = replace(templatestring(value.content, local.bicep_module_file_replacements), "$$${", "$${")
+      content = replace(replace(templatestring(value.content, local.bicep_module_file_replacements), "subscriptionsToPlaceInManagementGroup: ['']", "subscriptionsToPlaceInManagementGroup: []"), "$$${", "$${")
     }
   }
 


### PR DESCRIPTION
## Overview/Summary

This PR fixes Bug  @#4195(https://github.com/Azure/Azure-Landing-Zones/issues/4195) by correctly rendering empty subscription arrays for optional platform subscriptions in the generated Bicep parameter files.

Previously, when the Identity or Security subscription IDs were left empty, the generated `.bicepparam` files contained:

```bicep
subscriptionsToPlaceInManagementGroup: ['']
```

This PR updates the rendering logic so that empty subscription values are rendered as:

```bicep
subscriptionsToPlaceInManagementGroup: []
```

while preserving valid subscription IDs.

## This PR fixes/adds/changes/removes

1. Updates the Bicep file rendering logic in `modules/file_manipulation/locals.bicep.tf`.
2. Converts `subscriptionsToPlaceInManagementGroup: ['']` to `subscriptionsToPlaceInManagementGroup: []` after template rendering.
3. Preserves valid subscription IDs and arrays.
4. Scopes the replacement specifically to `subscriptionsToPlaceInManagementGroup` so unrelated `['']` values are not modified.

## Validation

Validation was performed using the ALZ Accelerator with the following configuration:

- - IaC: Bicep
- Management subscription: Configured
- Connectivity subscription: Configured
- Identity and Security subscriptions: Tested with both empty and individually empty configurations

Verified that:

- Both Identity and Security empty → `subscriptionsToPlaceInManagementGroup: []`.
- Only Identity empty → empty subscription array is rendered as `[]`.
- Only Security empty → empty subscription array is rendered as `[]`.
- Valid Management and Connectivity subscription IDs are preserved.
- Multiple valid subscription IDs are preserved unchanged.
- An unrelated `['']` value remains unchanged.

The final rendering therefore removes the invalid empty subscription entry only from the affected parameter while preserving unrelated values.

Fixes #4195