### PR TITLE
feat(bootstrap): expose move_subscriptions_to_target_management_group toggle (#4205)

### DIFF
--- a/alz/azuredevops/main.tf
+++ b/alz/azuredevops/main.tf
@@ -71,7 +71,7 @@ module "azure" {
   intermediate_root_management_group_creation_enabled       = var.iac_type != "bicep-classic"
   intermediate_root_management_group_id                     = module.file_manipulation.intermediate_root_management_group_id
   intermediate_root_management_group_display_name           = module.file_manipulation.intermediate_root_management_group_display_name
-  move_subscriptions_to_target_management_group             = var.iac_type != "bicep-classic"
+  move_subscriptions_to_target_management_group             = var.move_subscriptions_to_target_management_group != null ? var.move_subscriptions_to_target_management_group : (var.iac_type != "bicep-classic")
 }
 
 module "azure_devops" {

--- a/alz/azuredevops/variables.tf
+++ b/alz/azuredevops/variables.tf
@@ -7,6 +7,18 @@ variable "iac_type" {
   type        = string
 }
 
+variable "move_subscriptions_to_target_management_group" {
+  description = <<-EOT
+    **(Optional)** Whether to move the target subscriptions under the intermediate root management group.
+
+    Defaults to `true` for Terraform and Bicep (and `false` for bicep-classic). Set to `false` for brownfield
+    estates where the platform subscriptions are already placed in a management group hierarchy, to avoid
+    relocating them during bootstrap.
+  EOT
+  type        = bool
+  default     = null
+}
+
 variable "module_folder_path" {
   description = <<-EOT
     **(Required)** The filesystem path to the folder containing ALZ starter modules.

--- a/alz/github/main.tf
+++ b/alz/github/main.tf
@@ -72,7 +72,7 @@ module "azure" {
   intermediate_root_management_group_creation_enabled       = var.iac_type != "bicep-classic"
   intermediate_root_management_group_id                     = module.file_manipulation.intermediate_root_management_group_id
   intermediate_root_management_group_display_name           = module.file_manipulation.intermediate_root_management_group_display_name
-  move_subscriptions_to_target_management_group             = var.iac_type != "bicep-classic"
+  move_subscriptions_to_target_management_group             = var.move_subscriptions_to_target_management_group != null ? var.move_subscriptions_to_target_management_group : (var.iac_type != "bicep-classic")
 }
 
 module "github" {

--- a/alz/github/variables.tf
+++ b/alz/github/variables.tf
@@ -7,6 +7,18 @@ variable "iac_type" {
   type        = string
 }
 
+variable "move_subscriptions_to_target_management_group" {
+  description = <<-EOT
+    **(Optional)** Whether to move the target subscriptions under the intermediate root management group.
+
+    Defaults to `true` for Terraform and Bicep (and `false` for bicep-classic). Set to `false` for brownfield
+    estates where the platform subscriptions are already placed in a management group hierarchy, to avoid
+    relocating them during bootstrap.
+  EOT
+  type        = bool
+  default     = null
+}
+
 variable "module_folder_path" {
   description = <<-EOT
     **(Required)** The filesystem path to the folder containing ALZ starter modules.

--- a/alz/local/main.tf
+++ b/alz/local/main.tf
@@ -45,7 +45,7 @@ module "azure" {
   intermediate_root_management_group_creation_enabled  = var.iac_type != "bicep-classic"
   intermediate_root_management_group_id                = module.file_manipulation.intermediate_root_management_group_id
   intermediate_root_management_group_display_name      = module.file_manipulation.intermediate_root_management_group_display_name
-  move_subscriptions_to_target_management_group        = var.iac_type != "bicep-classic"
+  move_subscriptions_to_target_management_group        = var.move_subscriptions_to_target_management_group != null ? var.move_subscriptions_to_target_management_group : (var.iac_type != "bicep-classic")
 }
 
 module "file_manipulation" {

--- a/alz/local/variables.tf
+++ b/alz/local/variables.tf
@@ -7,6 +7,18 @@ variable "iac_type" {
   type        = string
 }
 
+variable "move_subscriptions_to_target_management_group" {
+  description = <<-EOT
+    **(Optional)** Whether to move the target subscriptions under the intermediate root management group.
+
+    Defaults to `true` for Terraform and Bicep (and `false` for bicep-classic). Set to `false` for brownfield
+    estates where the platform subscriptions are already placed in a management group hierarchy, to avoid
+    relocating them during bootstrap.
+  EOT
+  type        = bool
+  default     = null
+}
+
 variable "module_folder_path" {
   description = <<-EOT
     **(Required)** The filesystem path to the folder containing ALZ starter modules.


### PR DESCRIPTION
## Summary

Resolves #4205.

Exposes a new **optional** input `move_subscriptions_to_target_management_group` so that estates can opt out of relocating their platform subscriptions during bootstrap. Previously this was hardcoded to `var.iac_type != "bicep-classic"` with no way to override it, which forced subscription moves even for brownfield estates whose platform subscriptions are already placed in a management group hierarchy.

The input is added to all three VCS variants (`azuredevops`, `github`, `local`) and is **fully backward-compatible**: when left unset (`null`) the effective value is exactly today's behaviour.

## Changes

- Add `variable "move_subscriptions_to_target_management_group"` (`type = bool`, `default = null`) to:
  - `alz/azuredevops/variables.tf`
  - `alz/github/variables.tf`
  - `alz/local/variables.tf`
- Wire it into each `alz/<vcs>/main.tf` when calling `module "azure"`:

  ```hcl
  move_subscriptions_to_target_management_group = var.move_subscriptions_to_target_management_group != null ? var.move_subscriptions_to_target_management_group : (var.iac_type != "bicep-classic")
  ```

  The pre-change expression (`var.iac_type != "bicep-classic"`) remains the fallback, so unset = unchanged behaviour.

The consuming module input already exists (`modules/azure/variables.tf`) and gates the `azapi_resource.subscription_placement` `for_each` in `modules/azure/subscription_placements.tf`.

## Usage (`inputs.yaml`)

No allowlist or schema change is required. The accelerator generates the bootstrap tfvars from the module's Terraform variables matched to `inputs.yaml` **by name** (`Convert-HCLVariablesToInputConfig` → `Set-Config` → `Write-TfvarsJsonFile`); the interactive-wizard schema (`AcceleratorInputSchema.json`) only enriches prompts and never gates values. Declaring the variable in `alz/<vcs>/variables.tf` (this PR) makes it settable directly:

```yaml
# inputs.yaml
move_subscriptions_to_target_management_group: false
```

Left unset, behaviour is unchanged (`true` for Terraform/Bicep, `false` for bicep-classic).

## Validation

- `terraform fmt -check -recursive alz` — clean.
- `terraform init` + `terraform validate` — **"Success! The configuration is valid."** for `alz/local`, `alz/github`, and `alz/azuredevops`.

Behavioural check (same brownfield Terraform estate, `target_subscriptions = [management, connectivity, identity, security]` — matching the issue's 4-subscription plan excerpt):

| Scenario | `iac_type` | toggle | effective value | subscription placements |
|---|---|---|---|---|
| Default (unchanged) | `terraform` | *unset* | `true` | 4 |
| Brownfield opt-out | `terraform` | `false` | `false` | **0** |
| bicep-classic (unchanged) | `bicep-classic` | *unset* | `false` | 0 |
| Explicit opt-in | `terraform` | `true` | `true` | 4 |

Setting the toggle to `false` cleanly drops the subscription placements to `0` (no subscriptions relocated), while the unset default preserves current behaviour.

## Docs

A companion documentation update (migration guidance) will be raised separately in `Azure/Azure-Landing-Zones` and is intended to merge after this change is released.
