### PR TITLE
fix: use native azurerm attribute for ACR task network bypass

### DIFF
--- a/modules/azure/container_registry.tf
+++ b/modules/azure/container_registry.tf
@@ -1,23 +1,13 @@
 resource "azurerm_container_registry" "alz" {
-  count                         = var.use_self_hosted_agents ? 1 : 0
-  name                          = var.container_registry_name
-  resource_group_name           = azurerm_resource_group.agents[0].name
-  location                      = var.azure_location
-  sku                           = var.use_private_networking ? "Premium" : "Basic"
-  public_network_access_enabled = !var.use_private_networking
-  zone_redundancy_enabled       = var.use_private_networking && var.container_registry_zone_redundancy_enabled
-  network_rule_bypass_option    = var.use_private_networking ? "AzureServices" : "None"
-}
-
-resource "azapi_update_resource" "network_rule_bypass_allowed_for_tasks" {
-  count       = var.use_self_hosted_agents && var.use_private_networking ? 1 : 0
-  type        = "Microsoft.ContainerRegistry/registries@2025-05-01-preview"
-  resource_id = azurerm_container_registry.alz[0].id
-  body = {
-    properties = {
-      networkRuleBypassAllowedForTasks = true
-    }
-  }
+  count                                 = var.use_self_hosted_agents ? 1 : 0
+  name                                  = var.container_registry_name
+  resource_group_name                   = azurerm_resource_group.agents[0].name
+  location                              = var.azure_location
+  sku                                   = var.use_private_networking ? "Premium" : "Basic"
+  public_network_access_enabled         = !var.use_private_networking
+  zone_redundancy_enabled               = var.use_private_networking && var.container_registry_zone_redundancy_enabled
+  network_rule_bypass_option            = var.use_private_networking ? "AzureServices" : "None"
+  network_rule_bypass_for_tasks_enabled = var.use_private_networking
 }
 
 resource "azurerm_container_registry_task" "alz" {
@@ -51,8 +41,7 @@ resource "azurerm_container_registry_task_schedule_run_now" "alz" {
     replace_triggered_by = [azurerm_container_registry_task.alz]
   }
   depends_on = [
-    azurerm_role_assignment.container_registry_push_for_task,
-    azapi_update_resource.network_rule_bypass_allowed_for_tasks
+    azurerm_role_assignment.container_registry_push_for_task
   ]
 }
 

--- a/modules/azure/terraform.tf
+++ b/modules/azure/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.20"
+      version = "~> 4.81"
     }
     azapi = {
       source  = "azure/azapi"


### PR DESCRIPTION
## Overview/Summary

`azapi_update_resource.network_rule_bypass_allowed_for_tasks` (added in #102) sets `networkRuleBypassAllowedForTasks` on a registry that `azurerm_container_registry.alz` also manages.

azurerm `4.81.0` added `network_rule_bypass_for_tasks_enabled` to `azurerm_container_registry`. In the provider schema it is `optional = true, computed = false`, so leaving it unset means "use the schema default", not "leave the existing value alone". The provider therefore reverts what azapi wrote, and every subsequent plan against a private networking deployment shows:

```text
~ azurerm_container_registry.alz[0]
    ~ network_rule_bypass_for_tasks_enabled = true -> false
```

Applying that reverts the bypass. With `public_network_access_enabled = false` this is the flag the build task relies on to reach the registry, so image builds are at risk.

This sets the attribute natively and removes the azapi workaround.

## This PR fixes/adds/changes/removes

1. Sets `network_rule_bypass_for_tasks_enabled = var.use_private_networking` on `azurerm_container_registry.alz`.
2. Removes `azapi_update_resource.network_rule_bypass_allowed_for_tasks` and its reference in the `azurerm_container_registry_task_schedule_run_now.alz` `depends_on`. Ordering is preserved implicitly, since the task run already depends on the task, which depends on the registry.
3. Raises the azurerm constraint in `modules/azure/terraform.tf` from `~> 4.20` to `~> 4.81`.

### Breaking Changes

The azurerm minimum moves to `4.81.0`. Verified by schema inspection that `4.80.0` and earlier do not expose `network_rule_bypass_for_tasks_enabled`, so the constraint bump is required rather than optional.

Existing deployments are not modified. `azapi_update_resource` destroy is a state only operation, and the azurerm resource asserts the same value, so the registry is left as is.

## Testing Evidence

Tested against a deployed bootstrap using self hosted runners with private networking, where the registry already carried the flag set by the current code.

Registry state before, showing the azapi value in place:

```json
{
  "publicAccess": "Disabled",
  "bypassOption": "AzureServices",
  "bypassForTasks": true,
  "sku": "Premium"
}
```

Plan on the current `main`, showing the reverting diff:

```text
~ azurerm_container_registry.alz[0]
    ~ network_rule_bypass_for_tasks_enabled = true -> false

Plan: 4 to add, 1 to change, 0 to destroy.
```

Plan on this branch, against the same state and the same registry:

```text
# module.azure.azapi_update_resource.network_rule_bypass_allowed_for_tasks[0] will be destroyed
# (because azapi_update_resource.network_rule_bypass_allowed_for_tasks is not in configuration)

Plan: 4 to add, 0 to change, 1 to destroy.
```

`0 to change` confirms the diff is resolved. The single destroy is the azapi resource leaving state; the registry itself is untouched.

`terraform validate` passes and `make fmt` reports no further changes.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-terraform-accelerator/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/alz-terraform-accelerator/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/alz-terraform-accelerator/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
