### PR TITLE
fix: reauthenticate before deployment stack retries

### DIFF
--- a/alz/github/actions/bicep/templates/actions/bicep-deploy/action.yaml
+++ b/alz/github/actions/bicep/templates/actions/bicep-deploy/action.yaml
@@ -187,6 +187,30 @@ runs:
                 Write-Host "Retrying deployment stack after $retryDelay seconds..." -ForegroundColor Yellow
                 Start-Sleep -Seconds $retryDelay
                 Write-Host "Retry attempt $retryCount" -ForegroundColor Yellow
+                if (
+                  [string]::IsNullOrWhiteSpace($env:ACTIONS_ID_TOKEN_REQUEST_URL) -or
+                  [string]::IsNullOrWhiteSpace($env:ACTIONS_ID_TOKEN_REQUEST_TOKEN) -or
+                  [string]::IsNullOrWhiteSpace($env:AZURE_CLIENT_ID) -or
+                  [string]::IsNullOrWhiteSpace($env:AZURE_TENANT_ID)
+                ) {
+                  Write-Warning "Skipping re-authentication because required OIDC variables are unavailable."
+                } else {
+                  try {
+                    Write-Host "Re-authenticating to Azure using OIDC..." -ForegroundColor Cyan
+                    $oidcToken = Invoke-RestMethod `
+                      -Uri "$($env:ACTIONS_ID_TOKEN_REQUEST_URL)&audience=api://AzureADTokenExchange" `
+                      -Headers @{ Authorization = "Bearer $($env:ACTIONS_ID_TOKEN_REQUEST_TOKEN)" }
+                    Disable-AzContextAutosave -Scope Process | Out-Null
+                    Connect-AzAccount -ServicePrincipal `
+                      -ApplicationId $env:AZURE_CLIENT_ID `
+                      -TenantId $env:AZURE_TENANT_ID `
+                      -FederatedToken $oidcToken.value `
+                      -ErrorAction Stop | Out-Null
+                    Write-Host "Re-authentication succeeded" -ForegroundColor Green
+                  } catch {
+                    Write-Warning "Re-authentication failed: $($_.Exception.Message). Continuing with the existing Azure context."
+                  }
+                }
               }
 
               $result = $null
@@ -334,3 +358,5 @@ runs:
         DEPLOYMENT_TYPE: $${{ inputs.deploymentType }}
         FIRST_RUN_WHAT_IF: $${{ inputs.firstRunWhatIf }}
         WHAT_IF_ENABLED: $${{ inputs.whatIfEnabled }}
+        AZURE_CLIENT_ID: $${{ env.AZURE_CLIENT_ID }}
+        AZURE_TENANT_ID: $${{ env.AZURE_TENANT_ID }}

--- a/alz/github/actions/bicep/templates/actions/bicep-deploy/action.yaml
+++ b/alz/github/actions/bicep/templates/actions/bicep-deploy/action.yaml
@@ -197,10 +197,10 @@ runs:
                 } else {
                   try {
                     Write-Host "Re-authenticating to Azure using OIDC..." -ForegroundColor Cyan
-$oidcToken = Invoke-RestMethod -Method Get `
-  -Uri "$($env:ACTIONS_ID_TOKEN_REQUEST_URL)&audience=api://AzureADTokenExchange" `
-  -Headers @{ Authorization = "Bearer $($env:ACTIONS_ID_TOKEN_REQUEST_TOKEN)" } `
-  -ErrorAction Stop
+                    $oidcToken = Invoke-RestMethod -Method Get `
+                      -Uri "$($env:ACTIONS_ID_TOKEN_REQUEST_URL)&audience=api://AzureADTokenExchange" `
+                      -Headers @{ Authorization = "Bearer $($env:ACTIONS_ID_TOKEN_REQUEST_TOKEN)" } `
+                      -ErrorAction Stop
                     Disable-AzContextAutosave -Scope Process | Out-Null
                     Connect-AzAccount -ServicePrincipal `
                       -ApplicationId $env:AZURE_CLIENT_ID `

--- a/alz/github/actions/bicep/templates/actions/bicep-deploy/action.yaml
+++ b/alz/github/actions/bicep/templates/actions/bicep-deploy/action.yaml
@@ -197,9 +197,10 @@ runs:
                 } else {
                   try {
                     Write-Host "Re-authenticating to Azure using OIDC..." -ForegroundColor Cyan
-                    $oidcToken = Invoke-RestMethod `
-                      -Uri "$($env:ACTIONS_ID_TOKEN_REQUEST_URL)&audience=api://AzureADTokenExchange" `
-                      -Headers @{ Authorization = "Bearer $($env:ACTIONS_ID_TOKEN_REQUEST_TOKEN)" }
+$oidcToken = Invoke-RestMethod -Method Get `
+  -Uri "$($env:ACTIONS_ID_TOKEN_REQUEST_URL)&audience=api://AzureADTokenExchange" `
+  -Headers @{ Authorization = "Bearer $($env:ACTIONS_ID_TOKEN_REQUEST_TOKEN)" } `
+  -ErrorAction Stop
                     Disable-AzContextAutosave -Scope Process | Out-Null
                     Connect-AzAccount -ServicePrincipal `
                       -ApplicationId $env:AZURE_CLIENT_ID `

--- a/alz/github/actions/bicep/templates/workflows/cd-template.yaml
+++ b/alz/github/actions/bicep/templates/workflows/cd-template.yaml
@@ -87,6 +87,8 @@ jobs:
       contents: read
     env:
       PARAMETERS_FILE_NAME: parameters.json
+      AZURE_CLIENT_ID: $${{ vars.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: $${{ vars.AZURE_TENANT_ID }}
 
     steps:
       - name: Show inputs


### PR DESCRIPTION
Fixes #4209

## Summary

Long-running deployment stack operations can outlive the Azure authentication context established at the start of the deployment workflow. This change refreshes Azure authentication before deployment stack retry attempts using a fresh GitHub OIDC token.

## Changes

### Workflow Template

Updated:

- `alz/github/actions/bicep/templates/workflows/cd-template.yaml`

Added:

- `AZURE_CLIENT_ID`
- `AZURE_TENANT_ID`

to the deploy job environment so they can be used by the deployment action during retry operations.

### Deployment Action

Updated:

- `alz/github/actions/bicep/templates/actions/bicep-deploy/action.yaml`

Added retry-time reauthentication logic that:

- Validates required OIDC and Azure identity variables are available.
- Requests a fresh GitHub OIDC token.
- Reauthenticates using `Connect-AzAccount` with federated credentials.
- Continues with the existing Azure context if reauthentication is unavailable or fails.

## Validation

- Verified Azure identity variables are propagated from the deploy workflow to the deployment action.
- Verified Azure OIDC re-authentication executes successfully during deployment stack retry attempts.
- Preserved existing retry behavior and retry timing.
-Existing retry behavior is preserved when re-authentication is not performed.
`