### PR TITLE
fix: Use Terraform releases 'latest' endpoint to resolve null releases

### DIFF
--- a/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-installer.yaml
+++ b/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-installer.yaml
@@ -11,13 +11,12 @@ steps:
       $release = $null
 
       if($TF_VERSION -eq "latest") {
-        $versionResponse = Invoke-WebRequest -Uri "https://api.releases.hashicorp.com/v1/releases/terraform?limit=20"
+        $versionResponse = Invoke-WebRequest -Uri "https://api.releases.hashicorp.com/v1/releases/terraform/latest"
         if($versionResponse.StatusCode -ne "200") {
             throw "Unable to query Terraform version, please check your internet connection and try again..."
         }
-        $releases = ($versionResponse).Content | ConvertFrom-Json | Where-Object -Property is_prerelease -EQ $false
-        $release = $releases[0]
-        $TF_VERSION = $releases[0].version
+        $release = ($versionResponse).Content | ConvertFrom-Json
+        $TF_VERSION = $release.version
       } else {
           $versionResponse = Invoke-WebRequest -Uri "https://api.releases.hashicorp.com/v1/releases/terraform/$($TF_VERSION)"
           if($versionResponse.StatusCode -ne "200") {


### PR DESCRIPTION
## Summary

Fixes [#4242](https://github.com/Azure/Azure-Landing-Zones/issues/4242)

When using the AzureDevOps Terraform pipeline template with `terraformVersion: latest`, the pipeline can fail on certain PowerShell versions (observed on PowerShell 5.1 during testing) with the error:

```
Line |
  14 |    $release = $releases[0]
     |    ~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot index into a null array.
```

## Root Cause

The current implementation queries `https://api.releases.hashicorp.com/v1/releases/terraform?limit=20` and filters the results with `Where-Object -Property is_prerelease -EQ $false`, then takes the first element (`$releases[0]`) as the latest release.

This logic can behave inconsistently across different PowerShell versions, depending on how the underlying HTTP client parses the response. On some versions, this results in `$releases` evaluating to `$null`, causing the subsequent index operation to throw.

## Fix

Replace the `?limit=20` + filter/index approach with a direct call to the dedicated **latest release endpoint**:

```
https://api.releases.hashicorp.com/v1/releases/terraform/latest
```

This endpoint returns the latest stable Terraform release directly as a single JSON object, removing the need to filter/index an array and avoiding the version-specific parsing inconsistency entirely.

## Changes

- Updated `alz/azuredevops/pipelines/terraform/templates/helpers/terraform-installer.yaml` to call `/v1/releases/terraform/latest` instead of `/v1/releases/terraform?limit=20` when `$TF_VERSION -eq "latest"`.
- Removed the now-unnecessary `Where-Object -Property is_prerelease -EQ $false` filtering and array indexing logic.

## Testing

- Verified the pipeline installs Terraform successfully on the PowerShell version where the issue was originally reproduced, with `terraformVersion: latest`.
- Verified the pipeline continues to work correctly on other PowerShell versions.
- Verified pinned version installs (`terraformVersion: <specific version>`) are unaffected.