### PR TITLE
feat: store Terraform plans securely between pipeline stages

### DIFF
--- a/alz/azuredevops/locals.tf
+++ b/alz/azuredevops/locals.tf
@@ -34,6 +34,18 @@ locals {
 }
 
 locals {
+  # Deterministic, bounded plan-container name (Azure/Azure-Landing-Zones#4174). Storage container names
+  # must be 3-63 characters, so a short state-container name gets a readable "-tfplan" suffix; a name that
+  # would overflow 63 characters instead gets a stable hash-derived name so it never exceeds the limit.
+  create_plan_storage_container = var.iac_type == local.iac_terraform && var.use_storage_account_for_plan
+  plan_storage_container_name = local.create_plan_storage_container ? (
+    length(local.resource_names.storage_container) <= 56 ?
+    "${local.resource_names.storage_container}-tfplan" :
+    "tfplan-${substr(sha256(local.resource_names.storage_container), 0, 32)}"
+  ) : null
+}
+
+locals {
   target_subscriptions = distinct([for v in values(var.subscription_ids) : v if v != null && v != ""])
 }
 

--- a/alz/azuredevops/main.tf
+++ b/alz/azuredevops/main.tf
@@ -25,6 +25,9 @@ module "azure" {
   create_storage_account                                    = var.iac_type == local.iac_terraform
   storage_account_name                                      = local.resource_names.storage_account
   storage_container_name                                    = local.resource_names.storage_container
+  create_plan_storage_container                             = local.create_plan_storage_container
+  plan_storage_container_name                               = local.plan_storage_container_name
+  plan_storage_retention_days                               = var.plan_storage_retention_days
   azure_location                                            = var.bootstrap_location
   user_assigned_managed_identities                          = local.managed_identities
   federated_credentials                                     = local.federated_credentials
@@ -75,32 +78,35 @@ module "azure" {
 }
 
 module "azure_devops" {
-  source                                       = "../../modules/azure_devops"
-  use_legacy_organization_url                  = var.azure_devops_use_organisation_legacy_url
-  organization_name                            = var.azure_devops_organization_name
-  create_project                               = var.azure_devops_create_project
-  project_name                                 = var.azure_devops_project_name
-  environments                                 = local.environments
-  managed_identity_client_ids                  = module.azure.user_assigned_managed_identity_client_ids
-  repository_name                              = local.resource_names.version_control_system_repository
-  repository_files                             = module.file_manipulation.repository_files
-  template_repository_files                    = module.file_manipulation.template_repository_files
-  use_template_repository                      = var.use_separate_repository_for_templates
-  repository_name_templates                    = local.resource_names.version_control_system_repository_templates
-  variable_group_name                          = local.resource_names.version_control_system_variable_group
-  azure_tenant_id                              = data.azurerm_client_config.current.tenant_id
-  azure_subscription_id                        = var.subscription_ids["management"]
-  azure_subscription_name                      = data.azurerm_subscription.management.display_name
-  pipelines                                    = local.pipelines
-  backend_azure_resource_group_name            = local.resource_names.resource_group_state
-  backend_azure_storage_account_name           = local.resource_names.storage_account
-  backend_azure_storage_account_container_name = local.resource_names.storage_container
-  approvers                                    = var.apply_approvers
-  group_name                                   = local.resource_names.version_control_system_group
-  agent_pool_name                              = local.resource_names.version_control_system_agent_pool
-  use_self_hosted_agents                       = var.use_self_hosted_agents
-  create_branch_policies                       = var.create_branch_policies
-  create_variable_group                        = var.iac_type == "terraform"
+  source                                            = "../../modules/azure_devops"
+  use_legacy_organization_url                       = var.azure_devops_use_organisation_legacy_url
+  organization_name                                 = var.azure_devops_organization_name
+  create_project                                    = var.azure_devops_create_project
+  project_name                                      = var.azure_devops_project_name
+  environments                                      = local.environments
+  managed_identity_client_ids                       = module.azure.user_assigned_managed_identity_client_ids
+  repository_name                                   = local.resource_names.version_control_system_repository
+  repository_files                                  = module.file_manipulation.repository_files
+  template_repository_files                         = module.file_manipulation.template_repository_files
+  use_template_repository                           = var.use_separate_repository_for_templates
+  repository_name_templates                         = local.resource_names.version_control_system_repository_templates
+  variable_group_name                               = local.resource_names.version_control_system_variable_group
+  azure_tenant_id                                   = data.azurerm_client_config.current.tenant_id
+  azure_subscription_id                             = var.subscription_ids["management"]
+  azure_subscription_name                           = data.azurerm_subscription.management.display_name
+  pipelines                                         = local.pipelines
+  backend_azure_resource_group_name                 = local.resource_names.resource_group_state
+  backend_azure_storage_account_name                = local.resource_names.storage_account
+  backend_azure_storage_account_container_name      = local.resource_names.storage_container
+  use_storage_account_for_plan                      = local.create_plan_storage_container
+  show_plan_in_pipeline_logs                        = var.show_plan_in_pipeline_logs
+  backend_azure_storage_account_plan_container_name = local.plan_storage_container_name
+  approvers                                         = var.apply_approvers
+  group_name                                        = local.resource_names.version_control_system_group
+  agent_pool_name                                   = local.resource_names.version_control_system_agent_pool
+  use_self_hosted_agents                            = var.use_self_hosted_agents
+  create_branch_policies                            = var.create_branch_policies
+  create_variable_group                             = var.iac_type == "terraform"
 }
 
 module "file_manipulation" {

--- a/alz/azuredevops/pipelines/terraform/templates/cd-template.yaml
+++ b/alz/azuredevops/pipelines/terraform/templates/cd-template.yaml
@@ -30,6 +30,9 @@ stages:
                 - template: helpers/terraform-installer.yaml
                   parameters:
                     terraformVersion: $${{ parameters.terraform_cli_version }}
+                - template: helpers/terraform-plan-workspace.yaml
+                  parameters:
+                    purpose: 'plan'
                 - template: helpers/terraform-init.yaml
                   parameters:
                     serviceConnection: '${service_connection_name_plan}'
@@ -42,6 +45,26 @@ stages:
                     terraform_action: $${{ parameters.terraform_action }}
                     serviceConnection: '${service_connection_name_plan}'
                     root_module_folder_relative_path: $${{ parameters.root_module_folder_relative_path }}
+                - pwsh: |
+                    $planFile = Join-Path $env:ALZ_PLAN_DIR "tfplan"
+                    $arguments = @(
+                      "-chdir=$${{ parameters.root_module_folder_relative_path }}"
+                      "show"
+                      $planFile
+                    )
+                    & terraform $arguments
+                    if ($LASTEXITCODE -ne 0) {
+                      throw "Terraform show failed with exit code $LASTEXITCODE."
+                    }
+                  displayName: Show the Plan for Review
+                  condition: and(succeeded(), eq(variables['SHOW_PLAN_IN_PIPELINE_LOGS'], 'true'))
+                  env:
+                    ALZ_PLAN_DIR: $(alzPlanDir)
+                - template: helpers/terraform-plan-upload.yaml
+                  parameters:
+                    serviceConnection: '${service_connection_name_plan}'
+                # The plan file lives in the agent temp directory, so it is structurally absent from the
+                # sources directory this artifact is built from (Azure/Azure-Landing-Zones#4174).
                 - task: CopyFiles@2
                   displayName: Create Module Artifact
                   inputs:
@@ -54,21 +77,33 @@ stages:
                       !**/.terraform/**/*
                       !**/.git/**/*
                       !**/.pipelines/**/*
-                    TargetFolder: '$(Build.ArtifactsStagingDirectory)'
+                      !**/tfplan
+                      !**/tfplan.json
+                    TargetFolder: '$(Build.ArtifactStagingDirectory)'
                     CleanTargetFolder: true
                     OverWrite: true
+                - pwsh: |
+                    # Legacy behaviour: hand the plan off inside the pipeline artifact, where anyone with
+                    # pipeline read access can download it. Only reached when the storage hand-off is
+                    # explicitly disabled. The plan must land at the same root-module-relative path the
+                    # apply stage reads it back from, which is not necessarily the artifact root.
+                    $planFile = Join-Path $env:ALZ_PLAN_DIR "tfplan"
+                    $destinationFolder = Join-Path $env:ALZ_STAGING_DIR "$${{ parameters.root_module_folder_relative_path }}"
+                    New-Item -Path $destinationFolder -ItemType Directory -Force | Out-Null
+                    Copy-Item -Path $planFile -Destination (Join-Path $destinationFolder "tfplan") -Force
+                    Write-Host "##vso[task.logissue type=warning]USE_STORAGE_ACCOUNT_FOR_PLAN is not 'true', so the Terraform plan file is published inside the pipeline artifact and is readable by anyone with pipeline read access."
+                  displayName: Add Plan to Module Artifact
+                  condition: and(succeeded(), ne(variables['USE_STORAGE_ACCOUNT_FOR_PLAN'], 'true'))
+                  env:
+                    ALZ_PLAN_DIR: $(alzPlanDir)
+                    ALZ_STAGING_DIR: $(Build.ArtifactStagingDirectory)
                 - task: PublishPipelineArtifact@1
                   displayName: Publish Module Artifact
                   inputs:
-                    targetPath: '$(Build.ArtifactsStagingDirectory)'
+                    targetPath: '$(Build.ArtifactStagingDirectory)'
                     artifact: 'module'
                     publishLocation: 'pipeline'
-                - pwsh: |
-                    terraform `
-                    -chdir="$${{ parameters.root_module_folder_relative_path }}" `
-                    show `
-                    tfplan
-                  displayName: Show the Plan for Review
+                - template: helpers/terraform-plan-cleanup.yaml
   - stage: apply
     displayName: Apply
     dependsOn: plan
@@ -97,6 +132,12 @@ stages:
                 - template: helpers/terraform-installer.yaml
                   parameters:
                     terraformVersion: $${{ parameters.terraform_cli_version }}
+                - template: helpers/terraform-plan-workspace.yaml
+                  parameters:
+                    purpose: 'apply'
+                - template: helpers/terraform-plan-download.yaml
+                  parameters:
+                    serviceConnection: '${service_connection_name_apply}'
                 - template: helpers/terraform-init.yaml
                   parameters:
                     serviceConnection: '${service_connection_name_apply}'
@@ -109,3 +150,9 @@ stages:
                     terraform_action: $${{ parameters.terraform_action }}
                     serviceConnection: '${service_connection_name_apply}'
                     root_module_folder_relative_path: $${{ parameters.root_module_folder_relative_path }}
+                # Best-effort immediate cleanup on the happy path only. A failed apply deliberately leaves
+                # the blob in place; the container lifecycle policy is the guaranteed eventual cleanup.
+                - template: helpers/terraform-plan-delete.yaml
+                  parameters:
+                    serviceConnection: '${service_connection_name_apply}'
+                - template: helpers/terraform-plan-cleanup.yaml

--- a/alz/azuredevops/pipelines/terraform/templates/ci-template.yaml
+++ b/alz/azuredevops/pipelines/terraform/templates/ci-template.yaml
@@ -54,6 +54,9 @@ stages:
                 - template: helpers/terraform-installer.yaml
                   parameters:
                     terraformVersion: $${{ parameters.terraform_cli_version }}
+                - template: helpers/terraform-plan-workspace.yaml
+                  parameters:
+                    purpose: 'validate'
                 - template: helpers/terraform-init.yaml
                   parameters:
                     serviceConnection: '${service_connection_name_plan}'
@@ -65,3 +68,6 @@ stages:
                   parameters:
                     serviceConnection: '${service_connection_name_plan}'
                     root_module_folder_relative_path: $${{ parameters.root_module_folder_relative_path }}
+                # Validation only needs the plan to succeed; the plan file itself is never handed off or
+                # published, so it is destroyed with the rest of the temp directory.
+                - template: helpers/terraform-plan-cleanup.yaml

--- a/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-apply.yaml
+++ b/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-apply.yaml
@@ -30,12 +30,28 @@ steps:
         $env:ARM_USE_AZUREAD = "true"
         $env:AZAPI_RETRY_GET_AFTER_PUT_MAX_TIME = "60m" # Accounts for eventually consistent management group permissions propagation
 
+        # When the plan is handed off through Blob Storage it was downloaded into the agent temp
+        # directory; the legacy path still reads it from the extracted pipeline artifact.
+        if ($env:ALZ_USE_STORAGE_ACCOUNT_FOR_PLAN -eq 'true') {
+          $planFile = Join-Path $env:ALZ_PLAN_DIR "tfplan"
+        } else {
+          $planFile = "tfplan"
+        }
+
         # Run Terraform Apply
         $command = "terraform"
         $arguments = @()
         $arguments += "-chdir=$${{ parameters.root_module_folder_relative_path }}"
         $arguments += "apply"
+        $arguments += "-input=false"
         $arguments += "-auto-approve"
-        $arguments += "tfplan"
+        $arguments += $planFile
         Write-Host "Running: $command $arguments"
         & $command $arguments
+        if ($LASTEXITCODE -ne 0) {
+          throw "Terraform apply failed with exit code $LASTEXITCODE."
+        }
+
+    env:
+      ALZ_PLAN_DIR: $(alzPlanDir)
+      ALZ_USE_STORAGE_ACCOUNT_FOR_PLAN: $(USE_STORAGE_ACCOUNT_FOR_PLAN)

--- a/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-plan-cleanup.yaml
+++ b/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-plan-cleanup.yaml
@@ -1,0 +1,14 @@
+---
+steps:
+  # The path arrives as an environment variable rather than an inline $(alzPlanDir) macro so that an
+  # unset variable degrades to a harmless literal string instead of being evaluated as PowerShell.
+  - pwsh: |
+      $planDir = $env:ALZ_PLAN_DIR
+      if (-not [string]::IsNullOrEmpty($planDir) -and (Test-Path -Path $planDir)) {
+        Remove-Item -Path $planDir -Recurse -Force
+        Write-Host "Removed plan working directory '$planDir'."
+      }
+    displayName: Clean Up Plan Working Directory
+    condition: always()
+    env:
+      ALZ_PLAN_DIR: $(alzPlanDir)

--- a/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-plan-delete.yaml
+++ b/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-plan-delete.yaml
@@ -1,0 +1,44 @@
+---
+parameters:
+  - name: serviceConnection
+
+steps:
+  - task: AzureCLI@2
+    displayName: Delete Applied Plan from Storage
+    condition: and(succeeded(), eq(variables['USE_STORAGE_ACCOUNT_FOR_PLAN'], 'true'))
+    inputs:
+      azureSubscription: $${{ parameters.serviceConnection }}
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        $storageAccount = $env:ALZ_STORAGE_ACCOUNT
+        $container = $env:ALZ_PLAN_CONTAINER
+        $blobName = "runs/$env:ALZ_BUILD_ID/tfplan"
+
+        $maxAttempts = 3
+        $delaySeconds = 5
+        $deleted = $false
+        for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+          az storage blob delete `
+            --account-name $storageAccount `
+            --container-name $container `
+            --name $blobName `
+            --auth-mode login `
+            --only-show-errors
+          if ($LASTEXITCODE -eq 0) {
+            $deleted = $true
+            break
+          }
+          Write-Host "Delete attempt $attempt failed with exit code $LASTEXITCODE."
+          if ($attempt -lt $maxAttempts) {
+            Start-Sleep -Seconds $delaySeconds
+            $delaySeconds *= 2
+          }
+        }
+        if (-not $deleted) {
+          Write-Warning "Failed to delete applied plan blob '$blobName' after $maxAttempts attempts. It will be removed automatically by the container's lifecycle policy."
+        }
+    env:
+      ALZ_STORAGE_ACCOUNT: $(BACKEND_AZURE_STORAGE_ACCOUNT_NAME)
+      ALZ_PLAN_CONTAINER: $(PLAN_STORAGE_CONTAINER_NAME)
+      ALZ_BUILD_ID: $(Build.BuildId)

--- a/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-plan-download.yaml
+++ b/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-plan-download.yaml
@@ -1,0 +1,52 @@
+---
+parameters:
+  - name: serviceConnection
+
+steps:
+  - task: AzureCLI@2
+    displayName: Download Plan from Storage
+    condition: and(succeeded(), eq(variables['USE_STORAGE_ACCOUNT_FOR_PLAN'], 'true'))
+    inputs:
+      azureSubscription: $${{ parameters.serviceConnection }}
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        $planFile = Join-Path $env:ALZ_PLAN_DIR "tfplan"
+        $storageAccount = $env:ALZ_STORAGE_ACCOUNT
+        $container = $env:ALZ_PLAN_CONTAINER
+        $blobName = "runs/$env:ALZ_BUILD_ID/tfplan"
+
+        $maxAttempts = 3
+        $delaySeconds = 5
+        $downloaded = $false
+        for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+          az storage blob download `
+            --account-name $storageAccount `
+            --container-name $container `
+            --name $blobName `
+            --file $planFile `
+            --auth-mode login `
+            --only-show-errors
+          if ($LASTEXITCODE -eq 0) {
+            $downloaded = $true
+            break
+          }
+          Write-Host "Download attempt $attempt failed with exit code $LASTEXITCODE."
+          if ($attempt -lt $maxAttempts) {
+            Start-Sleep -Seconds $delaySeconds
+            $delaySeconds *= 2
+          }
+        }
+        if (-not $downloaded) {
+          throw "Failed to download plan blob '$blobName' after $maxAttempts attempts. Failing closed: no fallback to a stale or missing plan."
+        }
+        if (-not (Test-Path -Path $planFile) -or (Get-Item -Path $planFile).Length -eq 0) {
+          throw "Downloaded plan blob '$blobName' is missing or empty."
+        }
+
+        Write-Host "Downloaded plan blob '$blobName' to '$planFile'."
+    env:
+      ALZ_PLAN_DIR: $(alzPlanDir)
+      ALZ_STORAGE_ACCOUNT: $(BACKEND_AZURE_STORAGE_ACCOUNT_NAME)
+      ALZ_PLAN_CONTAINER: $(PLAN_STORAGE_CONTAINER_NAME)
+      ALZ_BUILD_ID: $(Build.BuildId)

--- a/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-plan-upload.yaml
+++ b/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-plan-upload.yaml
@@ -1,0 +1,70 @@
+---
+parameters:
+  - name: serviceConnection
+
+steps:
+  - task: AzureCLI@2
+    displayName: Upload Plan to Storage
+    condition: and(succeeded(), eq(variables['USE_STORAGE_ACCOUNT_FOR_PLAN'], 'true'))
+    inputs:
+      azureSubscription: $${{ parameters.serviceConnection }}
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        $planFile = Join-Path $env:ALZ_PLAN_DIR "tfplan"
+        $storageAccount = $env:ALZ_STORAGE_ACCOUNT
+        $container = $env:ALZ_PLAN_CONTAINER
+        $blobName = "runs/$env:ALZ_BUILD_ID/tfplan"
+
+        if (-not (Test-Path -Path $planFile)) {
+          throw "Plan file '$planFile' was not produced by the plan step."
+        }
+        $localLength = (Get-Item -Path $planFile).Length
+        if ($localLength -eq 0) {
+          throw "Plan file '$planFile' is empty."
+        }
+
+        $maxAttempts = 3
+        $delaySeconds = 5
+        $uploaded = $false
+        for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+          az storage blob upload `
+            --account-name $storageAccount `
+            --container-name $container `
+            --name $blobName `
+            --file $planFile `
+            --auth-mode login `
+            --overwrite `
+            --only-show-errors
+          if ($LASTEXITCODE -eq 0) {
+            $uploaded = $true
+            break
+          }
+          Write-Host "Upload attempt $attempt failed with exit code $LASTEXITCODE."
+          if ($attempt -lt $maxAttempts) {
+            Start-Sleep -Seconds $delaySeconds
+            $delaySeconds *= 2
+          }
+        }
+        if (-not $uploaded) {
+          throw "Failed to upload plan blob '$blobName' after $maxAttempts attempts."
+        }
+
+        $remoteLength = az storage blob show `
+          --account-name $storageAccount `
+          --container-name $container `
+          --name $blobName `
+          --auth-mode login `
+          --query properties.contentLength `
+          --only-show-errors `
+          -o tsv
+        if ([string]::IsNullOrEmpty($remoteLength) -or [int64]$remoteLength -ne $localLength) {
+          throw "Uploaded plan blob '$blobName' content length ($remoteLength) does not match local file ($localLength)."
+        }
+
+        Write-Host "Uploaded plan blob '$blobName' ($localLength bytes) to container '$container'."
+    env:
+      ALZ_PLAN_DIR: $(alzPlanDir)
+      ALZ_STORAGE_ACCOUNT: $(BACKEND_AZURE_STORAGE_ACCOUNT_NAME)
+      ALZ_PLAN_CONTAINER: $(PLAN_STORAGE_CONTAINER_NAME)
+      ALZ_BUILD_ID: $(Build.BuildId)

--- a/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-plan-workspace.yaml
+++ b/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-plan-workspace.yaml
@@ -1,0 +1,22 @@
+---
+parameters:
+  - name: purpose
+    default: 'plan'
+
+steps:
+  - pwsh: |
+      # Keep the plan file out of $(Build.SourcesDirectory) so it can never be swept into the published
+      # pipeline artifact (Azure/Azure-Landing-Zones#4174). The job attempt is part of the *local* path
+      # only, never the remote blob key, so a retried job cannot pick up residue from an earlier attempt.
+      $planDir = Join-Path $env:ALZ_AGENT_TEMP "alz-$${{ parameters.purpose }}-$env:ALZ_BUILD_ID-$env:ALZ_JOB_ATTEMPT"
+      if (Test-Path -Path $planDir) {
+        Remove-Item -Path $planDir -Recurse -Force
+      }
+      New-Item -Path $planDir -ItemType Directory -Force | Out-Null
+      Write-Host "##vso[task.setvariable variable=alzPlanDir]$planDir"
+      Write-Host "Plan working directory: $planDir"
+    displayName: Prepare Plan Working Directory
+    env:
+      ALZ_AGENT_TEMP: $(Agent.TempDirectory)
+      ALZ_BUILD_ID: $(Build.BuildId)
+      ALZ_JOB_ATTEMPT: $(System.JobAttempt)

--- a/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-plan.yaml
+++ b/alz/azuredevops/pipelines/terraform/templates/helpers/terraform-plan.yaml
@@ -29,12 +29,17 @@ steps:
         $env:ARM_CLIENT_ID = $clientId
         $env:ARM_USE_AZUREAD = "true"
 
+        # Keep the plan file and its captured output outside the sources directory so neither can be
+        # swept into the published pipeline artifact (Azure/Azure-Landing-Zones#4174).
+        $planFile = Join-Path $env:ALZ_PLAN_DIR "tfplan"
+        $planLogFile = Join-Path $env:ALZ_PLAN_DIR "tfplan.log"
+
         # Run Terraform Plan
         $command = "terraform"
         $arguments = @()
         $arguments += "-chdir=$${{ parameters.root_module_folder_relative_path }}"
         $arguments += "plan"
-        $arguments += "-out=tfplan"
+        $arguments += "-out=$planFile"
         $arguments += "-input=false"
 
         if ($env:TERRAFORM_ACTION -eq 'destroy') {
@@ -42,7 +47,37 @@ steps:
         }
 
         Write-Host "Running: $command $arguments"
-        & $command $arguments
+        & $command $arguments *> $planLogFile
+        $planExitCode = $LASTEXITCODE
+
+        # Only print the full captured output when the pipeline is explicitly configured to show plan
+        # content. A failed plan can still have streamed resource attribute values to the log before the
+        # error occurred, so the failure path prints just Terraform's own diagnostic block(s) - its boxed
+        # "Error:"/"Warning:" sections - never the resource diff.
+        $showPlanInPipelineLogs = $env:ALZ_SHOW_PLAN_IN_PIPELINE_LOGS -eq 'true'
+        if ($showPlanInPipelineLogs) {
+          Get-Content -Path $planLogFile | Write-Host
+        } elseif ($planExitCode -ne 0) {
+          $logContent = Get-Content -Path $planLogFile -Raw
+          $diagnosticBlocks = [regex]::Matches($logContent, "(?ms)^\u2577.*?^\u2575")
+          if ($diagnosticBlocks.Count -gt 0) {
+            foreach ($block in $diagnosticBlocks) {
+              Write-Host $block.Value
+            }
+          } else {
+            Write-Host "Terraform plan failed. Set SHOW_PLAN_IN_PIPELINE_LOGS to true on the pipeline variable group to see full plan output for troubleshooting."
+          }
+        } else {
+          Write-Host "Terraform plan succeeded. Set SHOW_PLAN_IN_PIPELINE_LOGS to true on the pipeline variable group to see the full plan output."
+        }
+
+        Remove-Item -Path $planLogFile -Force -ErrorAction SilentlyContinue
+
+        if ($planExitCode -ne 0) {
+          throw "Terraform plan failed with exit code $planExitCode."
+        }
 
     env:
       TERRAFORM_ACTION: $${{ coalesce(parameters.terraform_action, 'apply') }}
+      ALZ_PLAN_DIR: $(alzPlanDir)
+      ALZ_SHOW_PLAN_IN_PIPELINE_LOGS: $(SHOW_PLAN_IN_PIPELINE_LOGS)

--- a/alz/azuredevops/variables.tf
+++ b/alz/azuredevops/variables.tf
@@ -617,6 +617,8 @@ variable "plan_storage_retention_days" {
     snapshots, and previous versions) become eligible for lifecycle deletion.
 
     Only applies when `use_storage_account_for_plan` is `true`. Must be a positive whole number.
+    Choose a value longer than the longest expected plan-to-apply approval wait. If a plan expires
+    before approval, rerun the pipeline to generate a fresh plan.
   EOT
   type        = number
   default     = 7

--- a/alz/azuredevops/variables.tf
+++ b/alz/azuredevops/variables.tf
@@ -587,6 +587,46 @@ variable "storage_account_replication_type" {
   default     = "ZRS"
 }
 
+variable "use_storage_account_for_plan" {
+  description = <<-EOT
+    **(Optional, default: `true`)** Use the state storage account to hand a Terraform plan file off between
+    the generated CD pipeline's plan and apply stages, instead of a native Azure Pipelines artifact.
+
+    `false` deliberately restores the legacy behavior of copying `tfplan` into the published module
+    artifact, where it is downloadable by anyone who can read the pipeline run.
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "show_plan_in_pipeline_logs" {
+  description = <<-EOT
+    **(Optional, default: `false`)** Allow the generated CI/CD pipelines to print the full human-readable
+    Terraform plan to the pipeline logs.
+
+    This is an explicit risk acceptance. When `false`, a plan failure prints only Terraform's own
+    diagnostic block(s) or a generic failure notice, never the resource diff.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "plan_storage_retention_days" {
+  description = <<-EOT
+    **(Optional, default: `7`)** Number of days after which abandoned Terraform plan blobs (base blobs,
+    snapshots, and previous versions) become eligible for lifecycle deletion.
+
+    Only applies when `use_storage_account_for_plan` is `true`. Must be a positive whole number.
+  EOT
+  type        = number
+  default     = 7
+
+  validation {
+    condition     = var.plan_storage_retention_days > 0 && var.plan_storage_retention_days == floor(var.plan_storage_retention_days)
+    error_message = "plan_storage_retention_days must be a positive whole number."
+  }
+}
+
 variable "bicep_config_file_path" {
   description = <<-EOT
     **(Optional, default: `".config/ALZ-Powershell.config.json"`)** Path to the Bicep configuration file.

--- a/alz/github/actions/terraform/templates/workflows/cd-template.yaml
+++ b/alz/github/actions/terraform/templates/workflows/cd-template.yaml
@@ -37,6 +37,14 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Azure Login
+        if: vars.USE_STORAGE_ACCOUNT_FOR_PLAN == 'true'
+        uses: azure/login@v2
+        with:
+          client-id: $${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: $${{ vars.AZURE_TENANT_ID }}
+          subscription-id: $${{ vars.AZURE_SUBSCRIPTION_ID }}
+
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
         with:
@@ -53,29 +61,136 @@ jobs:
           -backend-config="container_name=$${{vars.BACKEND_AZURE_STORAGE_ACCOUNT_CONTAINER_NAME}}" \
           -backend-config="key=terraform.tfstate"
 
-      - name: Terraform Plan for $${{ inputs.terraform_action == 'destroy' && 'Destroy' || 'Apply' }}
+      - name: Prepare Plan Working Directory
+        id: plan_paths
+        shell: pwsh
         run: |
-          # shellcheck disable=SC2086
+          $planDir = Join-Path $env:RUNNER_TEMP "plan-$${{ github.run_id }}-$${{ github.run_attempt }}"
+          if (Test-Path -Path $planDir) {
+            Remove-Item -Path $planDir -Recurse -Force
+          }
+          New-Item -Path $planDir -ItemType Directory -Force | Out-Null
+          "plan_dir=$planDir" >> $env:GITHUB_OUTPUT
+
+      - name: Terraform Plan for $${{ inputs.terraform_action == 'destroy' && 'Destroy' || 'Apply' }}
+        shell: pwsh
+        run: |
+          $action = "$${{ inputs.terraform_action }}"
+          $planFile = Join-Path "$${{ steps.plan_paths.outputs.plan_dir }}" "tfplan"
+          $planLogFile = Join-Path "$${{ steps.plan_paths.outputs.plan_dir }}" "tfplan.log"
+
+          $command = "terraform"
+          $arguments = @()
+          $arguments += "-chdir=$${{ inputs.root_module_folder_relative_path }}"
+          $arguments += "plan"
+          $arguments += "-out=$planFile"
+          $arguments += "-input=false"
+
+          if ($action -eq 'destroy') {
+            $arguments += "-destroy"
+          }
+
+          Write-Host "Running: $command $arguments"
+          & $command $arguments *> $planLogFile
+          $planExitCode = $LASTEXITCODE
+
+          if ($planExitCode -ne 0) {
+            # A failed plan can still have streamed resource attribute values to the log before
+            # the error occurred. Only print the full captured output when the pipeline is
+            # explicitly configured to show plan content; otherwise print just Terraform's own
+            # diagnostic block(s) (its boxed "Error:"/"Warning:" sections), never the resource diff.
+            $showPlanInPipelineLogs = "$${{ vars.SHOW_PLAN_IN_PIPELINE_LOGS }}" -eq 'true'
+            if ($showPlanInPipelineLogs) {
+              Get-Content -Path $planLogFile | Write-Host
+            } else {
+              $logContent = Get-Content -Path $planLogFile -Raw
+              $diagnosticBlocks = [regex]::Matches($logContent, "(?ms)^\u2577.*?^\u2575")
+              if ($diagnosticBlocks.Count -gt 0) {
+                foreach ($block in $diagnosticBlocks) {
+                  Write-Host $block.Value
+                }
+              } else {
+                Write-Host "Terraform plan failed. Set SHOW_PLAN_IN_PIPELINE_LOGS to true on this environment to see full plan output for troubleshooting."
+              }
+            }
+            throw "Terraform plan failed with exit code $planExitCode."
+          }
+
+      - name: Show the Plan for Review
+        if: vars.SHOW_PLAN_IN_PIPELINE_LOGS == 'true'
+        shell: pwsh
+        run: |
+          $planFile = Join-Path "$${{ steps.plan_paths.outputs.plan_dir }}" "tfplan"
           terraform \
           -chdir="$${{inputs.root_module_folder_relative_path}}" \
-          plan \
-          -out=tfplan \
-          -input=false \
-          $${{ inputs.terraform_action == 'destroy' && '-destroy' || '' }}
+          show \
+          $planFile
+
+      - name: Upload Plan to Storage
+        if: vars.USE_STORAGE_ACCOUNT_FOR_PLAN == 'true'
+        shell: pwsh
+        run: |
+          $planFile = Join-Path "$${{ steps.plan_paths.outputs.plan_dir }}" "tfplan"
+          $storageAccount = "$${{ vars.BACKEND_AZURE_STORAGE_ACCOUNT_NAME }}"
+          $container = "$${{ vars.PLAN_STORAGE_CONTAINER_NAME }}"
+          $blobName = "runs/$${{ github.run_id }}/tfplan"
+          $localLength = (Get-Item -Path $planFile).Length
+
+          $maxAttempts = 3
+          $delaySeconds = 5
+          $uploaded = $false
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            az storage blob upload `
+              --account-name $storageAccount `
+              --container-name $container `
+              --name $blobName `
+              --file $planFile `
+              --auth-mode login `
+              --overwrite `
+              --only-show-errors
+            if ($LASTEXITCODE -eq 0) {
+              $uploaded = $true
+              break
+            }
+            Write-Host "Upload attempt $attempt failed with exit code $LASTEXITCODE."
+            if ($attempt -lt $maxAttempts) {
+              Start-Sleep -Seconds $delaySeconds
+              $delaySeconds *= 2
+            }
+          }
+          if (-not $uploaded) {
+            throw "Failed to upload plan blob '$blobName' after $maxAttempts attempts."
+          }
+
+          $remoteLength = az storage blob show `
+            --account-name $storageAccount `
+            --container-name $container `
+            --name $blobName `
+            --auth-mode login `
+            --query properties.contentLength `
+            --only-show-errors `
+            -o tsv
+          if ([string]::IsNullOrEmpty($remoteLength) -or [int64]$remoteLength -ne $localLength) {
+            throw "Uploaded plan blob '$blobName' content length ($remoteLength) does not match local file ($localLength)."
+          }
 
       - name: Create Module Artifact
+        shell: pwsh
         run: |
           $stagingDirectory = "staging"
           $rootModuleFolder = "$${{inputs.root_module_folder_relative_path}}"
           New-Item -Path . -Name $stagingDirectory -ItemType "directory"
-          Copy-Item -Path "./*" -Exclude @(".git", ".terraform", ".github",  $stagingDirectory) -Recurse -Destination "./$stagingDirectory"
+          Copy-Item -Path "./*" -Exclude @(".git", ".terraform", ".github", $stagingDirectory) -Recurse -Destination "./$stagingDirectory"
 
           $rootModuleFolderTerraformFolder = Join-Path -Path "./$stagingDirectory" -ChildPath $rootModuleFolder -AdditionalChildPath ".terraform"
           if(Test-Path -Path $rootModuleFolderTerraformFolder) {
             Remove-Item -Path $rootModuleFolderTerraformFolder -Recurse -Force
           }
 
-        shell: pwsh
+          if ("$${{ vars.USE_STORAGE_ACCOUNT_FOR_PLAN }}" -ne 'true') {
+            $planFile = Join-Path "$${{ steps.plan_paths.outputs.plan_dir }}" "tfplan"
+            Copy-Item -Path $planFile -Destination "./$stagingDirectory/tfplan"
+          }
 
       - name: Publish Module Artifact
         uses: actions/upload-artifact@v4
@@ -83,12 +198,14 @@ jobs:
           name: module
           path: ./staging/
 
-      - name: Show the Plan for Review
+      - name: Clean Up Plan Working Directory
+        if: always()
+        shell: pwsh
         run: |
-          terraform \
-          -chdir="$${{inputs.root_module_folder_relative_path}}" \
-          show \
-          tfplan
+          $planDir = "$${{ steps.plan_paths.outputs.plan_dir }}"
+          if (-not [string]::IsNullOrEmpty($planDir) -and (Test-Path -Path $planDir)) {
+            Remove-Item -Path $planDir -Recurse -Force
+          }
 
   apply:
     needs: plan
@@ -114,11 +231,67 @@ jobs:
         with:
           name: module
 
+      - name: Azure Login
+        if: vars.USE_STORAGE_ACCOUNT_FOR_PLAN == 'true'
+        uses: azure/login@v2
+        with:
+          client-id: $${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: $${{ vars.AZURE_TENANT_ID }}
+          subscription-id: $${{ vars.AZURE_SUBSCRIPTION_ID }}
+
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
           terraform_version: $${{ inputs.terraform_cli_version }}
+
+      - name: Prepare Plan Working Directory
+        id: plan_paths
+        shell: pwsh
+        run: |
+          $planDir = Join-Path $env:RUNNER_TEMP "apply-$${{ github.run_id }}-$${{ github.run_attempt }}"
+          if (Test-Path -Path $planDir) {
+            Remove-Item -Path $planDir -Recurse -Force
+          }
+          New-Item -Path $planDir -ItemType Directory -Force | Out-Null
+          "plan_dir=$planDir" >> $env:GITHUB_OUTPUT
+
+      - name: Download Plan from Storage
+        if: vars.USE_STORAGE_ACCOUNT_FOR_PLAN == 'true'
+        shell: pwsh
+        run: |
+          $planFile = Join-Path "$${{ steps.plan_paths.outputs.plan_dir }}" "tfplan"
+          $storageAccount = "$${{ vars.BACKEND_AZURE_STORAGE_ACCOUNT_NAME }}"
+          $container = "$${{ vars.PLAN_STORAGE_CONTAINER_NAME }}"
+          $blobName = "runs/$${{ github.run_id }}/tfplan"
+
+          $maxAttempts = 3
+          $delaySeconds = 5
+          $downloaded = $false
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            az storage blob download `
+              --account-name $storageAccount `
+              --container-name $container `
+              --name $blobName `
+              --file $planFile `
+              --auth-mode login `
+              --only-show-errors
+            if ($LASTEXITCODE -eq 0) {
+              $downloaded = $true
+              break
+            }
+            Write-Host "Download attempt $attempt failed with exit code $LASTEXITCODE."
+            if ($attempt -lt $maxAttempts) {
+              Start-Sleep -Seconds $delaySeconds
+              $delaySeconds *= 2
+            }
+          }
+          if (-not $downloaded) {
+            throw "Failed to download plan blob '$blobName' after $maxAttempts attempts. Failing closed: no fallback to a stale or missing plan."
+          }
+          if (-not (Test-Path -Path $planFile) -or (Get-Item -Path $planFile).Length -eq 0) {
+            throw "Downloaded plan blob '$blobName' is missing or empty."
+          }
 
       - name: Terraform Init
         run: |
@@ -131,10 +304,58 @@ jobs:
           -backend-config="key=terraform.tfstate"
 
       - name: Terraform $${{ inputs.terraform_action == 'destroy' && 'Destroy' || 'Apply' }}
+        shell: pwsh
         run: |
+          if ("$${{ vars.USE_STORAGE_ACCOUNT_FOR_PLAN }}" -eq 'true') {
+            $planFile = Join-Path "$${{ steps.plan_paths.outputs.plan_dir }}" "tfplan"
+          } else {
+            $planFile = "tfplan"
+          }
+
           terraform \
           -chdir="$${{inputs.root_module_folder_relative_path}}" \
           apply \
           -input=false \
           -auto-approve \
-          tfplan
+          $planFile
+
+      - name: Delete Applied Plan from Storage
+        if: success() && vars.USE_STORAGE_ACCOUNT_FOR_PLAN == 'true'
+        shell: pwsh
+        run: |
+          $storageAccount = "$${{ vars.BACKEND_AZURE_STORAGE_ACCOUNT_NAME }}"
+          $container = "$${{ vars.PLAN_STORAGE_CONTAINER_NAME }}"
+          $blobName = "runs/$${{ github.run_id }}/tfplan"
+
+          $maxAttempts = 3
+          $delaySeconds = 5
+          $deleted = $false
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            az storage blob delete `
+              --account-name $storageAccount `
+              --container-name $container `
+              --name $blobName `
+              --auth-mode login `
+              --only-show-errors
+            if ($LASTEXITCODE -eq 0) {
+              $deleted = $true
+              break
+            }
+            Write-Host "Delete attempt $attempt failed with exit code $LASTEXITCODE."
+            if ($attempt -lt $maxAttempts) {
+              Start-Sleep -Seconds $delaySeconds
+              $delaySeconds *= 2
+            }
+          }
+          if (-not $deleted) {
+            Write-Warning "Failed to delete applied plan blob '$blobName' after $maxAttempts attempts. It will be removed automatically by the container's lifecycle policy."
+          }
+
+      - name: Clean Up Plan Working Directory
+        if: always()
+        shell: pwsh
+        run: |
+          $planDir = "$${{ steps.plan_paths.outputs.plan_dir }}"
+          if (-not [string]::IsNullOrEmpty($planDir) -and (Test-Path -Path $planDir)) {
+            Remove-Item -Path $planDir -Recurse -Force
+          }

--- a/alz/github/actions/terraform/templates/workflows/cd-template.yaml
+++ b/alz/github/actions/terraform/templates/workflows/cd-template.yaml
@@ -193,8 +193,13 @@ jobs:
           }
 
           if ("$${{ vars.USE_STORAGE_ACCOUNT_FOR_PLAN }}" -ne 'true') {
+            # Legacy behaviour: the plan travels inside the artifact, readable by anyone who can read the
+            # workflow run. It must land at the same root-module-relative path the apply job reads it back
+            # from, which is not necessarily the artifact root.
             $planFile = Join-Path "$${{ steps.plan_paths.outputs.plan_dir }}" "tfplan"
-            Copy-Item -Path $planFile -Destination "./$stagingDirectory/tfplan"
+            $destinationFolder = Join-Path "./$stagingDirectory" $rootModuleFolder
+            New-Item -Path $destinationFolder -ItemType Directory -Force | Out-Null
+            Copy-Item -Path $planFile -Destination (Join-Path $destinationFolder "tfplan") -Force
           }
 
       - name: Publish Module Artifact

--- a/alz/github/actions/terraform/templates/workflows/cd-template.yaml
+++ b/alz/github/actions/terraform/templates/workflows/cd-template.yaml
@@ -121,10 +121,15 @@ jobs:
         shell: pwsh
         run: |
           $planFile = Join-Path "$${{ steps.plan_paths.outputs.plan_dir }}" "tfplan"
-          terraform \
-          -chdir="$${{inputs.root_module_folder_relative_path}}" \
-          show \
-          $planFile
+          $arguments = @(
+            "-chdir=$${{ inputs.root_module_folder_relative_path }}"
+            "show"
+            $planFile
+          )
+          & terraform $arguments
+          if ($LASTEXITCODE -ne 0) {
+            throw "Terraform show failed with exit code $LASTEXITCODE."
+          }
 
       - name: Upload Plan to Storage
         if: vars.USE_STORAGE_ACCOUNT_FOR_PLAN == 'true'
@@ -312,12 +317,18 @@ jobs:
             $planFile = "tfplan"
           }
 
-          terraform \
-          -chdir="$${{inputs.root_module_folder_relative_path}}" \
-          apply \
-          -input=false \
-          -auto-approve \
-          $planFile
+          $arguments = @(
+            "-chdir=$${{ inputs.root_module_folder_relative_path }}"
+            "apply"
+            "-input=false"
+            "-auto-approve"
+            $planFile
+          )
+
+          & terraform $arguments
+          if ($LASTEXITCODE -ne 0) {
+            throw "Terraform apply failed with exit code $LASTEXITCODE."
+          }
 
       - name: Delete Applied Plan from Storage
         if: success() && vars.USE_STORAGE_ACCOUNT_FOR_PLAN == 'true'

--- a/alz/github/actions/terraform/templates/workflows/ci-template.yaml
+++ b/alz/github/actions/terraform/templates/workflows/ci-template.yaml
@@ -91,11 +91,42 @@ jobs:
 
       - name: Terraform Plan
         id: plan
+        shell: pwsh
         run: |
-          terraform \
-          -chdir="$${{inputs.root_module_folder_relative_path}}" \
-          plan \
-          -input=false
+          $planLogFile = Join-Path $env:RUNNER_TEMP "tfplan-$${{ github.run_id }}-$${{ github.run_attempt }}.log"
+
+          terraform `
+          -chdir="$${{inputs.root_module_folder_relative_path}}" `
+          plan `
+          -input=false *> $planLogFile
+          $planExitCode = $LASTEXITCODE
+
+          # Only print the full captured output when the pipeline is explicitly configured to show
+          # plan content; a failed plan can still have streamed resource attribute values to the log
+          # before the error occurred, so the failure path prints just Terraform's own diagnostic
+          # block(s), never the resource diff.
+          $showPlanInPipelineLogs = "$${{ vars.SHOW_PLAN_IN_PIPELINE_LOGS }}" -eq 'true'
+          if ($showPlanInPipelineLogs) {
+            Get-Content -Path $planLogFile | Write-Host
+          } elseif ($planExitCode -ne 0) {
+            $logContent = Get-Content -Path $planLogFile -Raw
+            $diagnosticBlocks = [regex]::Matches($logContent, "(?ms)^\u2577.*?^\u2575")
+            if ($diagnosticBlocks.Count -gt 0) {
+              foreach ($block in $diagnosticBlocks) {
+                Write-Host $block.Value
+              }
+            } else {
+              Write-Host "Terraform plan failed. Set SHOW_PLAN_IN_PIPELINE_LOGS to true on this environment to see full plan output for troubleshooting."
+            }
+          } else {
+            Write-Host "Terraform plan succeeded. Set SHOW_PLAN_IN_PIPELINE_LOGS to true on this environment to see the full plan output."
+          }
+
+          Remove-Item -Path $planLogFile -Force -ErrorAction SilentlyContinue
+
+          if ($planExitCode -ne 0) {
+            throw "Terraform plan failed with exit code $planExitCode."
+          }
 
       - name: Update Pull Request
         if: (success() || failure()) && github.event_name == 'pull_request'

--- a/alz/github/locals.tf
+++ b/alz/github/locals.tf
@@ -41,6 +41,18 @@ locals {
 }
 
 locals {
+  # Deterministic, bounded plan-container name (Azure/Azure-Landing-Zones#4174). Storage container names
+  # must be 3-63 characters, so a short state-container name gets a readable "-tfplan" suffix; a name that
+  # would overflow 63 characters instead gets a stable hash-derived name so it never exceeds the limit.
+  create_plan_storage_container = var.iac_type == local.iac_terraform && var.use_storage_account_for_plan
+  plan_storage_container_name = local.create_plan_storage_container ? (
+    length(local.resource_names.storage_container) <= 56 ?
+    "${local.resource_names.storage_container}-tfplan" :
+    "tfplan-${substr(sha256(local.resource_names.storage_container), 0, 32)}"
+  ) : null
+}
+
+locals {
   target_subscriptions = distinct([for v in values(var.subscription_ids) : v if v != null && v != ""])
 }
 

--- a/alz/github/main.tf
+++ b/alz/github/main.tf
@@ -27,6 +27,9 @@ module "azure" {
   create_storage_account                                    = var.iac_type == local.iac_terraform
   storage_account_name                                      = local.resource_names.storage_account
   storage_container_name                                    = local.resource_names.storage_container
+  create_plan_storage_container                             = local.create_plan_storage_container
+  plan_storage_container_name                               = local.plan_storage_container_name
+  plan_storage_retention_days                               = var.plan_storage_retention_days
   azure_location                                            = var.bootstrap_location
   target_subscriptions                                      = local.target_subscriptions
   root_parent_management_group_id                           = local.root_parent_management_group_id
@@ -76,32 +79,35 @@ module "azure" {
 }
 
 module "github" {
-  source                                       = "../../modules/github"
-  domain_name                                  = var.github_organization_domain_name
-  organization_name                            = var.github_organization_name
-  environments                                 = local.environments
-  repository_name                              = local.resource_names.version_control_system_repository
-  use_template_repository                      = var.use_separate_repository_for_templates
-  repository_name_templates                    = local.resource_names.version_control_system_repository_templates
-  repository_files                             = module.file_manipulation.repository_files
-  template_repository_files                    = module.file_manipulation.template_repository_files
-  workflows                                    = local.workflows
-  managed_identity_client_ids                  = module.azure.user_assigned_managed_identity_client_ids
-  azure_tenant_id                              = data.azurerm_client_config.current.tenant_id
-  azure_subscription_id                        = var.subscription_ids["management"]
-  backend_azure_resource_group_name            = local.resource_names.resource_group_state
-  backend_azure_storage_account_name           = local.resource_names.storage_account
-  backend_azure_storage_account_container_name = local.resource_names.storage_container
-  approvers                                    = var.apply_approvers
-  create_team                                  = var.apply_approval_team_creation_enabled
-  existing_team_name                           = var.apply_approval_existing_team_name
-  team_name                                    = local.resource_names.version_control_system_team
-  runner_group_name                            = local.resource_names.version_control_system_runner_group
-  use_runner_group                             = local.use_runner_group
-  default_runner_group_name                    = var.default_runner_group_name
-  use_self_hosted_runners                      = var.use_self_hosted_runners
-  create_branch_policies                       = var.create_branch_policies
-  create_storage_account_variables             = var.iac_type == "terraform"
+  source                                            = "../../modules/github"
+  domain_name                                       = var.github_organization_domain_name
+  organization_name                                 = var.github_organization_name
+  environments                                      = local.environments
+  repository_name                                   = local.resource_names.version_control_system_repository
+  use_template_repository                           = var.use_separate_repository_for_templates
+  repository_name_templates                         = local.resource_names.version_control_system_repository_templates
+  repository_files                                  = module.file_manipulation.repository_files
+  template_repository_files                         = module.file_manipulation.template_repository_files
+  workflows                                         = local.workflows
+  managed_identity_client_ids                       = module.azure.user_assigned_managed_identity_client_ids
+  azure_tenant_id                                   = data.azurerm_client_config.current.tenant_id
+  azure_subscription_id                             = var.subscription_ids["management"]
+  backend_azure_resource_group_name                 = local.resource_names.resource_group_state
+  backend_azure_storage_account_name                = local.resource_names.storage_account
+  backend_azure_storage_account_container_name      = local.resource_names.storage_container
+  backend_azure_storage_account_plan_container_name = local.plan_storage_container_name
+  use_storage_account_for_plan                      = local.create_plan_storage_container
+  show_plan_in_pipeline_logs                        = var.show_plan_in_pipeline_logs
+  approvers                                         = var.apply_approvers
+  create_team                                       = var.apply_approval_team_creation_enabled
+  existing_team_name                                = var.apply_approval_existing_team_name
+  team_name                                         = local.resource_names.version_control_system_team
+  runner_group_name                                 = local.resource_names.version_control_system_runner_group
+  use_runner_group                                  = local.use_runner_group
+  default_runner_group_name                         = var.default_runner_group_name
+  use_self_hosted_runners                           = var.use_self_hosted_runners
+  create_branch_policies                            = var.create_branch_policies
+  create_storage_account_variables                  = var.iac_type == "terraform"
 }
 
 module "file_manipulation" {

--- a/alz/github/variables.tf
+++ b/alz/github/variables.tf
@@ -639,6 +639,46 @@ variable "storage_account_replication_type" {
   default     = "ZRS"
 }
 
+variable "use_storage_account_for_plan" {
+  description = <<-EOT
+    **(Optional, default: `true`)** Use the state storage account to hand a Terraform plan file off between
+    the generated CD workflow's plan and apply jobs, instead of a native GitHub Actions artifact.
+
+    `false` deliberately restores the legacy behavior of copying `tfplan` into the published module
+    artifact, where it is downloadable by anyone who can read the workflow run.
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "show_plan_in_pipeline_logs" {
+  description = <<-EOT
+    **(Optional, default: `false`)** Allow the generated CI/CD workflows to print the full human-readable
+    Terraform plan to the pipeline logs.
+
+    This is an explicit risk acceptance. When `false`, a plan failure prints only Terraform's own
+    diagnostic block(s) or a generic failure notice, never the resource diff.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "plan_storage_retention_days" {
+  description = <<-EOT
+    **(Optional, default: `7`)** Number of days after which abandoned Terraform plan blobs (base blobs,
+    snapshots, and previous versions) become eligible for lifecycle deletion.
+
+    Only applies when `use_storage_account_for_plan` is `true`. Must be a positive whole number.
+  EOT
+  type        = number
+  default     = 7
+
+  validation {
+    condition     = var.plan_storage_retention_days > 0 && var.plan_storage_retention_days == floor(var.plan_storage_retention_days)
+    error_message = "plan_storage_retention_days must be a positive whole number."
+  }
+}
+
 variable "bicep_config_file_path" {
   description = <<-EOT
     **(Optional, default: `".config/ALZ-Powershell.config.json"`)** Path to the Bicep configuration file.

--- a/alz/github/variables.tf
+++ b/alz/github/variables.tf
@@ -669,6 +669,8 @@ variable "plan_storage_retention_days" {
     snapshots, and previous versions) become eligible for lifecycle deletion.
 
     Only applies when `use_storage_account_for_plan` is `true`. Must be a positive whole number.
+    Choose a value longer than the longest expected plan-to-apply approval wait. If a plan expires
+    before approval, rerun the workflow to generate a fresh plan.
   EOT
   type        = number
   default     = 7

--- a/modules/azure/storage.tf
+++ b/modules/azure/storage.tf
@@ -71,3 +71,60 @@ resource "azurerm_role_assignment" "alz_storage_container_additional" {
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = each.value
 }
+
+# Transient container used to hand off a Terraform plan file from the plan job to the apply job
+# instead of a native pipeline artifact (Azure/Azure-Landing-Zones#4174).
+resource "azapi_resource" "storage_account_plan_container" {
+  count     = var.create_storage_account && var.create_plan_storage_container ? 1 : 0
+  type      = "Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01"
+  parent_id = data.azapi_resource_id.storage_account_blob_service[0].id
+  name      = var.plan_storage_container_name
+  body = {
+    properties = {
+      publicAccess = "None"
+    }
+  }
+  schema_validation_enabled = false
+  depends_on                = [azurerm_storage_account_network_rules.alz]
+}
+
+resource "azurerm_role_assignment" "alz_storage_plan_container" {
+  for_each             = var.create_storage_account && var.create_plan_storage_container ? var.user_assigned_managed_identities : {}
+  scope                = azapi_resource.storage_account_plan_container[0].id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.alz[each.key].principal_id
+}
+
+resource "azurerm_role_assignment" "alz_storage_plan_container_additional" {
+  for_each             = var.create_storage_account && var.create_plan_storage_container ? var.additional_role_assignment_principal_ids : {}
+  scope                = azapi_resource.storage_account_plan_container[0].id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = each.value
+}
+
+# Backstop cleanup for abandoned plan blobs. Azure lifecycle processing runs asynchronously
+# (normally once per day), so the retention period is a backstop, not an exact deletion timestamp.
+resource "azurerm_storage_management_policy" "alz_plan" {
+  count              = var.create_storage_account && var.create_plan_storage_container ? 1 : 0
+  storage_account_id = azurerm_storage_account.alz[0].id
+
+  rule {
+    name    = "planStorageRetention"
+    enabled = true
+    filters {
+      blob_types   = ["blockBlob"]
+      prefix_match = ["${var.plan_storage_container_name}/runs/"]
+    }
+    actions {
+      base_blob {
+        delete_after_days_since_modification_greater_than = var.plan_storage_retention_days
+      }
+      snapshot {
+        delete_after_days_since_creation_greater_than = var.plan_storage_retention_days
+      }
+      version {
+        delete_after_days_since_creation = var.plan_storage_retention_days
+      }
+    }
+  }
+}

--- a/modules/azure/variables.tf
+++ b/modules/azure/variables.tf
@@ -138,6 +138,8 @@ variable "plan_storage_retention_days" {
   description = <<-EOT
     **(Optional, default: `7`)** Number of days after which abandoned plan blobs (base blobs, snapshots,
     and previous versions) under `<plan-container>/runs/` become eligible for lifecycle deletion.
+    Choose a value longer than the longest expected plan-to-apply approval wait. Expired plans must be
+    regenerated rather than applied.
   EOT
   type        = number
   default     = 7

--- a/modules/azure/variables.tf
+++ b/modules/azure/variables.tf
@@ -113,6 +113,36 @@ variable "storage_container_name" {
   type        = string
 }
 
+variable "create_plan_storage_container" {
+  description = <<-EOT
+    **(Optional, default: `false`)** Controls whether to create the transient blob container used to hand
+    off a Terraform plan file from the plan job to the apply job instead of a native pipeline artifact.
+
+    Only takes effect when `create_storage_account` is also `true`. When `false`, no plan container,
+    plan-container role assignments, or plan-retention lifecycle rule are created.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "plan_storage_container_name" {
+  description = <<-EOT
+    **(Required when `create_plan_storage_container` is `true`)** Deterministic name of the blob container
+    used to store Terraform plan files uploaded by the plan job and downloaded by the apply job.
+  EOT
+  type        = string
+  default     = null
+}
+
+variable "plan_storage_retention_days" {
+  description = <<-EOT
+    **(Optional, default: `7`)** Number of days after which abandoned plan blobs (base blobs, snapshots,
+    and previous versions) under `<plan-container>/runs/` become eligible for lifecycle deletion.
+  EOT
+  type        = number
+  default     = 7
+}
+
 variable "storage_account_replication_type" {
   description = <<-EOT
     **(Optional, default: `"ZRS"`)** Replication strategy for the storage account.

--- a/modules/azure_devops/variable_group.tf
+++ b/modules/azure_devops/variable_group.tf
@@ -19,6 +19,25 @@ resource "azuredevops_variable_group" "alz" {
     name  = "BACKEND_AZURE_STORAGE_ACCOUNT_CONTAINER_NAME"
     value = var.backend_azure_storage_account_container_name
   }
+
+  variable {
+    name  = "USE_STORAGE_ACCOUNT_FOR_PLAN"
+    value = var.use_storage_account_for_plan ? "true" : "false"
+  }
+
+  variable {
+    name  = "SHOW_PLAN_IN_PIPELINE_LOGS"
+    value = var.show_plan_in_pipeline_logs ? "true" : "false"
+  }
+
+  dynamic "variable" {
+    for_each = var.use_storage_account_for_plan && var.backend_azure_storage_account_plan_container_name != null ? [1] : []
+
+    content {
+      name  = "PLAN_STORAGE_CONTAINER_NAME"
+      value = var.backend_azure_storage_account_plan_container_name
+    }
+  }
 }
 
 moved {

--- a/modules/azure_devops/variables.tf
+++ b/modules/azure_devops/variables.tf
@@ -212,6 +212,39 @@ variable "backend_azure_storage_account_container_name" {
   type        = string
 }
 
+variable "use_storage_account_for_plan" {
+  description = <<-EOT
+    **(Required)** Whether the generated CD pipeline hands a Terraform plan file off between the plan and
+    apply stages through the state storage account instead of a native Azure Pipelines artifact.
+
+    Published to the pipeline variable group as `USE_STORAGE_ACCOUNT_FOR_PLAN`, consumed by the generated
+    pipeline templates. Only meaningful when `create_variable_group` is `true`.
+  EOT
+  type        = bool
+}
+
+variable "show_plan_in_pipeline_logs" {
+  description = <<-EOT
+    **(Required)** Whether the generated CI/CD pipelines are allowed to print the full human-readable
+    Terraform plan to the pipeline logs.
+
+    Published to the pipeline variable group as `SHOW_PLAN_IN_PIPELINE_LOGS`. This is an explicit risk
+    acceptance; when `false` (the recommended default) only a generic failure notice or Terraform's own
+    diagnostic blocks are printed on plan failure, never the resource diff.
+  EOT
+  type        = bool
+}
+
+variable "backend_azure_storage_account_plan_container_name" {
+  description = <<-EOT
+    **(Optional, default: `null`)** Deterministic name of the blob container used to store Terraform plan
+    files. Published to the pipeline variable group as `PLAN_STORAGE_CONTAINER_NAME` when not null. Null
+    when `use_storage_account_for_plan` is `false`.
+  EOT
+  type        = string
+  default     = null
+}
+
 variable "approvers" {
   description = <<-EOT
     **(Required)** List of Azure DevOps user principal names (emails) authorized to approve deployments.

--- a/modules/github/action_variables.tf
+++ b/modules/github/action_variables.tf
@@ -39,6 +39,27 @@ resource "github_actions_variable" "backend_azure_storage_account_container_name
   value         = var.backend_azure_storage_account_container_name
 }
 
+resource "github_actions_variable" "use_storage_account_for_plan" {
+  count         = var.create_storage_account_variables ? 1 : 0
+  repository    = github_repository.alz.name
+  variable_name = "USE_STORAGE_ACCOUNT_FOR_PLAN"
+  value         = var.use_storage_account_for_plan ? "true" : "false"
+}
+
+resource "github_actions_variable" "show_plan_in_pipeline_logs" {
+  count         = var.create_storage_account_variables ? 1 : 0
+  repository    = github_repository.alz.name
+  variable_name = "SHOW_PLAN_IN_PIPELINE_LOGS"
+  value         = var.show_plan_in_pipeline_logs ? "true" : "false"
+}
+
+resource "github_actions_variable" "plan_storage_container_name" {
+  count         = var.create_storage_account_variables && var.use_storage_account_for_plan ? 1 : 0
+  repository    = github_repository.alz.name
+  variable_name = "PLAN_STORAGE_CONTAINER_NAME"
+  value         = var.backend_azure_storage_account_plan_container_name
+}
+
 moved {
   from = github_actions_variable.backend_azure_resource_group_name
   to   = github_actions_variable.backend_azure_resource_group_name[0]

--- a/modules/github/variables.tf
+++ b/modules/github/variables.tf
@@ -138,6 +138,39 @@ variable "backend_azure_storage_account_container_name" {
   type        = string
 }
 
+variable "use_storage_account_for_plan" {
+  description = <<-EOT
+    **(Required)** Whether the generated CD workflow hands a Terraform plan file off between the plan and
+    apply jobs through the state storage account instead of a native GitHub Actions artifact.
+
+    Published to the repository as the `USE_STORAGE_ACCOUNT_FOR_PLAN` Actions variable, consumed by the
+    generated workflow. Only meaningful when `create_storage_account_variables` is `true`.
+  EOT
+  type        = bool
+}
+
+variable "show_plan_in_pipeline_logs" {
+  description = <<-EOT
+    **(Required)** Whether the generated CI/CD workflows are allowed to print the full human-readable
+    Terraform plan to the pipeline logs.
+
+    Published to the repository as the `SHOW_PLAN_IN_PIPELINE_LOGS` Actions variable. This is an explicit
+    risk acceptance; when `false` (the recommended default) only a generic failure notice or Terraform's
+    own diagnostic blocks are printed on plan failure, never the resource diff.
+  EOT
+  type        = bool
+}
+
+variable "backend_azure_storage_account_plan_container_name" {
+  description = <<-EOT
+    **(Optional, default: `null`)** Deterministic name of the blob container used to store Terraform plan
+    files. Published to the repository as the `PLAN_STORAGE_CONTAINER_NAME` Actions variable when not
+    null. Null when `use_storage_account_for_plan` is `false`.
+  EOT
+  type        = string
+  default     = null
+}
+
 variable "approvers" {
   description = <<-EOT
     **(Required)** List of GitHub usernames who are authorized to approve deployments in protected environments.


### PR DESCRIPTION
## Description

Moves Terraform plan hand-off for both `alz/github` and `alz/azuredevops` from downloadable CI/CD artifacts to a dedicated container in the private Azure Storage account used for Terraform state.

Related to Azure/Azure-Landing-Zones#4174.

Companion production-module PRs:

- Azure/terraform-azure-avm-ptn-alz-application-landing-zone-cicd-bootstrap-github#51
- Azure/terraform-azure-avm-ptn-alz-application-landing-zone-cicd-bootstrap-azure-devops#51

### Security and compatibility

- Storage-backed hand-off is enabled by default with `use_storage_account_for_plan = true`.
- Each run addresses its exact `runs/<run-id>/tfplan` blob using Microsoft Entra ID/OIDC; no storage keys, blob listing, or mutable `latest` alias are used.
- Plan files and captured output remain in runner/agent temporary directories and are excluded from published artifacts.
- Full plan output is hidden by default with `show_plan_in_pipeline_logs = false`, including failed-plan output redaction.
- Upload and download fail closed. The active plan blob is deleted after successful apply; failed or abandoned plans remain available for lifecycle cleanup.
- `plan_storage_retention_days` defaults to 7 and is configurable for longer approval windows.
- `use_storage_account_for_plan = false` preserves the legacy artifact hand-off.
- The `avm-res-storage-storageaccount` dependency remains pinned at `0.6.8`.

### Implementation

- Provisions and validates a dedicated plan container with lifecycle retention.
- Publishes the storage feature flags and container name to GitHub Actions and Azure Pipelines.
- Updates both CI/CD template sets for exact-key upload/download, success-only deletion, temporary-directory cleanup, artifact exclusion, and safe log handling.

### Testing evidence

- `terraform init -backend=false` and `terraform validate` pass for both `alz/github` and `alz/azuredevops`.
- GitHub template YAML and Terraform-template escaping were statically validated, including 75/75 GitHub expression sites.
- Real GitHub validation covered upload/download/apply/delete, artifact absence, log gating, failed-apply retention, concurrency, and management-policy merge safety.
- Real Azure DevOps validation deployed 230 bootstrap resources and passed all 8 planned scenarios, including the secure path, legacy fallback, failure retention, concurrency, policy merge safety, and teardown.
- Companion contract suites pass: GitHub 65/65 assertions and Azure DevOps 66/66 assertions.
- All eligible automatic checks pass. The E2E matrix is gated by the `PR: Safe to test 🧪` label and will run when a maintainer adds that label.

### Known limitations

- Mocked Terraform unit tests cannot currently load the pinned storage module because Terraform `mock_provider` rejects its ephemeral `azapi_resource_action` (hashicorp/terraform#38608). The live matrices, contract suites, static checks, and Azure read-back provide compensating coverage.
- Azure Storage management policy is account-scoped and singleton. Existing rules are merged, and live testing confirmed an unrelated custom rule survived unchanged, but Terraform cannot enforce an upgrade preflight against an externally managed policy at plan time.

## Type of Change

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

The AVM module pre-commit command is not applicable to this repository. Native fmt, super-linter, title, and release checks pass; the gated E2E matrix awaits the maintainer-applied `PR: Safe to test 🧪` label.
